### PR TITLE
Heroku-capable build

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "test": "mocha 'test/**/*.js'"
   },
   "engines": {
-    "node": "18.17.6",
+    "node": "18.x",
     "npm": "9.8.x"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "scripts": {
     "start": "node serve.js",
-    "build": "gulp --series clean build",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider && gulp --series clean build",
     "test": "mocha 'test/**/*.js'"
   },
   "engines": {


### PR DESCRIPTION
**Before**
The hosted UI was served from a private copy of this repo, and Heroku was not capable of building from this repo

**After**
Heroku can build, using selecting a minor version of Node 18 and the legacy SSL option to satisfy webpack.

Beginning with this PR, [trivialapps.io](https://www.staging.trivialapps.io) is deployed automatically from main of this repo, and promoted manually to production.