### PR TITLE
Remove config from ChangePassword request

### DIFF
--- a/source/components/ChangePassword.vue
+++ b/source/components/ChangePassword.vue
@@ -96,9 +96,6 @@ export default {
                   password: this.new_password,
                   password_confirmation: this.confirm_password,
                   current_password: this.current_password,
-                  config: {
-                      check_current_password_before_update: true
-                  }
                 })
               })
               this.message = 'Password successfully updated!'


### PR DESCRIPTION
**Before**
Change Password Request includes `config` parameter

**After**
`config` parameter is removed

**Notes**
This parameter was unnecessary/misleading because it implies this is where the `current_password` requirement is sourced. Requirement for `current_password` with password change is actually sourced from config file in `trivial-api`