### PR TITLE
Small panel container row fix

### DIFF
--- a/source/components/Register.vue
+++ b/source/components/Register.vue
@@ -150,7 +150,7 @@ export default {
                 }
                 TrackingService.identify(user)
                 TrackingService.track('User Signup', user)
-                window.location = '/playground'
+                window.location = '/'
 		    }
         },
 

--- a/source/components/Register.vue
+++ b/source/components/Register.vue
@@ -150,7 +150,7 @@ export default {
                 }
                 TrackingService.identify(user)
                 TrackingService.track('User Signup', user)
-                window.location = '/'
+                window.location = '/playground'
 		    }
         },
 

--- a/source/components/panels/Dashboard.vue
+++ b/source/components/panels/Dashboard.vue
@@ -356,11 +356,14 @@
       margin-top: 3em;
       display: flex;
       flex-direction: column;
-
+      
       @media only screen and (min-width: 600px) {
-        flex-direction: row;
+        flex-flow: row wrap;
         justify-content: space-between;
       } 
+      .panel{
+        margin-top: 1em;
+      }
     }
   }
 


### PR DESCRIPTION
This is a small fix for row panel container. Currently the small panels inside a dashboard page are not going onto a new row when panels reach the max width on a row. This fix pushes small panels to a new row when max width is reached. 

What is currently on staging: 
<img width="1440" alt="Screen Shot 2023-12-18 at 2 00 31 PM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/dd32bc95-e80e-4471-8b07-7b41851b8e10">
<img width="1435" alt="Screen Shot 2023-12-18 at 2 00 40 PM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/90468265-7bcf-4539-9ec8-9acebbd2f0e7">

Changes in this PR:
<img width="1440" alt="Screen Shot 2023-12-18 at 1 59 52 PM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/c18f37a7-bf98-41f6-9d07-975c9235553c">
