### PR TITLE
respect theme defaults

### DIFF
--- a/source/assets/stylesheets/includes/_variables.scss
+++ b/source/assets/stylesheets/includes/_variables.scss
@@ -39,10 +39,10 @@ $series-4: #a4d976 !default; // green
 
 $on-background: #c7c0b8 !default;
 $on-background-high-contrast: #ffffff !default;
-$on-background-80: tone-for($on-background, $background, 80%);
-$on-background-60: tone-for($on-background, $background, 60%);
-$on-background-40: tone-for($on-background, $background, 40%);
-$on-background-20: tone-for($on-background, $background, 20%);
+$on-background-80: tone-for($on-background, $background, 80%) !default;
+$on-background-60: tone-for($on-background, $background, 60%) !default;
+$on-background-40: tone-for($on-background, $background, 40%) !default;
+$on-background-20: tone-for($on-background, $background, 20%) !default;
 $on-surface: #b0b6ec !default;
 $on-surface-secondary: #c7c0b8 !default;
 $on-primary: #ffffff !default;
@@ -71,9 +71,9 @@ $loading: url("/assets/images/trivial-loading.gif") !default;
 $auth-border-color: $accent !default;
 $auth-button-gradient: linear-gradient(45deg, #5147fe, #b61df6, #f46721) !default;
 
-$super-bar-background: #000;
-$toggle-background-light: #eee;
-$toggle-background-dark: #333;
+$super-bar-background: #000 !default;
+$toggle-background-light: #eee !default;
+$toggle-background-dark: #333 !default;
 
 //
 // Typography

--- a/source/components/AppsOverview.vue
+++ b/source/components/AppsOverview.vue
@@ -138,7 +138,7 @@
   }
 
  .tab.active, .active{
-    background-color: var(--accent-20);
+    background-color: var(--table-column-head-color);
     color: var(--on-background);
     border-bottom: 0;
     border-color: var(--accent);

--- a/source/components/controls/HideableSection.vue
+++ b/source/components/controls/HideableSection.vue
@@ -82,7 +82,7 @@
       position: absolute;
       top: 0;
       background-color: transparent;
-      color: var(--on-secondary);
+      color: var(--link);
       cursor: pointer;
       padding-left: 20px;
       text-transform: uppercase;
@@ -95,14 +95,14 @@
         width: 0;
         height: 0;
         border: 6px solid transparent;
-        border-bottom-color: var(--accent);
+        border-bottom-color: var(--link);
         opacity: .8;
       }
 
       &.closed:before {
         top: 9px;
         border-bottom-color: transparent;
-        border-top-color: var(--accent);
+        border-top-color: var(--link);
       }
     }
 

--- a/source/components/icons/trash.vue
+++ b/source/components/icons/trash.vue
@@ -4,5 +4,12 @@
 </script>
 
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path fill="#b0b6ec" d="M135.2 17.7L128 32H32C14.3 32 0 46.3 0 64S14.3 96 32 96H416c17.7 0 32-14.3 32-32s-14.3-32-32-32H320l-7.2-14.3C307.4 6.8 296.3 0 284.2 0H163.8c-12.1 0-23.2 6.8-28.6 17.7zM416 128H32L53.2 467c1.6 25.3 22.6 45 47.9 45H346.9c25.3 0 46.3-19.7 47.9-45L416 128z"/></svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M135.2 17.7L128 32H32C14.3 32 0 46.3 0 64S14.3 96 32 96H416c17.7 0 32-14.3 32-32s-14.3-32-32-32H320l-7.2-14.3C307.4 6.8 296.3 0 284.2 0H163.8c-12.1 0-23.2 6.8-28.6 17.7zM416 128H32L53.2 467c1.6 25.3 22.6 45 47.9 45H346.9c25.3 0 46.3-19.7 47.9-45L416 128z"/></svg>
 </template>
+
+
+<style lang="scss" scoped>
+  svg {
+    fill: var(--link);
+  }
+</style>


### PR DESCRIPTION
- Trash can icon renders in `link` color
- table header background actually renders in the var the stylesheet creates
- superbar background, toggle backgrounds, and background-Ns are declared as defaults, which allows them to be overridden with a custom theme