### PR TITLE
Fix for DashboardSettings tab and minor edit on Dashboard

### DIFF
--- a/source/components/panels/Dashboard.vue
+++ b/source/components/panels/Dashboard.vue
@@ -309,6 +309,7 @@
 
     h1 {
       display: inline;
+      margin-right: 10px;
     }
 
     h2 {

--- a/source/components/panels/DashboardSettings.vue
+++ b/source/components/panels/DashboardSettings.vue
@@ -189,13 +189,13 @@ input, select {
 }
 
 .dashboard-settings-container {
-  position: absolute;
-  top: 0;
+  position: fixed;
+  top: 80px;
   left: 0;
   background: var(--background);
   color: var(--on-background);
   padding: 2em;
-  height: calc(100% - 80px);
+  height: calc(100% - 80px - 4em);
   z-index: 10;
   max-width: 24em;
   box-shadow: 6px 0px 5px 0px var(--on-background-20);


### PR DESCRIPTION
Fixes #24 . This PR introduces a fix to the settings bar's height set relative to the height of the dashboard-container. Thus, when there are no apps presents the height of the settings-bar is very small and when there are multiples apps in the dashboard-container the height of the settings bar is very high. 

What's on staging:
<img width="1440" alt="Screen Shot 2023-12-19 at 11 24 57 AM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/370ae7b0-7054-44ca-aa09-7fb371ea0253">
<img width="1440" alt="Screen Shot 2023-12-19 at 11 25 29 AM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/53c8ad56-0acb-4b81-b82b-a306da52c31b">


Changes introduced:
- Settings bar is now fixed to the screen. Meaning it stays at the same position in the screen whenever you scroll. 
- Adding 10px to the right of title app, since I felt that the edit options where way too close to App title

<img width="1440" alt="Screen Shot 2023-12-19 at 11 24 44 AM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/2e39dec2-4482-46ca-8600-e63c2ca74d13">
<img width="1440" alt="Screen Shot 2023-12-19 at 11 22 12 AM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/6d2e9f2d-66cc-48c1-b15c-06230a50e1a4">
<img width="1440" alt="Screen Shot 2023-12-19 at 11 22 27 AM" src="https://github.com/solid-adventure/trivial-ui/assets/20259244/b60419fd-8210-4a28-a773-18a4d6d6e622">
