### PR TITLE
correct fallback

### DIFF
--- a/source/components/builderv2/EditorDefinition.vue
+++ b/source/components/builderv2/EditorDefinition.vue
@@ -35,7 +35,7 @@
       },
 
       actionSlotDisplayName() {
-        return this.descriptor.actionSlotDisplayName || this.descriptor.slotName
+        return this.descriptor.actionSlotDisplayName || this.descriptor.actionSlots[0] || ''
       },
 
       descriptor() {


### PR DESCRIPTION
**Before**
Fallback when descriptor.slotDisplayName isn't set misses, and we get `undefined` for the action list title.

![Screenshot 2023-12-20 at 3 27 40 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/4acbd198-896a-4782-88f1-81797600de3e)

**After**
Fallback hits, and we can render "Actions", "Rules", or any other name based on the outer action's `Descriptor.js`.
![Screenshot 2023-12-20 at 3 27 20 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/4eed21c8-afde-42da-9d3c-9d7148cfaa6a)
![Screenshot 2023-12-20 at 3 27 26 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/b2145bf6-a3bb-4a56-a8ce-0c5177446379)
