### PR TITLE
global page settings, account theme

### DIFF
--- a/source/assets/stylesheets/app.scss
+++ b/source/assets/stylesheets/app.scss
@@ -82,7 +82,20 @@ table.spaced {
 
 }
 
+div.page-container {
+  top: 80px;
+  margin: 2em;
+  position: relative;
+}
 
+div.page-inset {
+  background: var(--surface);
+  padding: 2em 3em;
+  border-radius: 1em;
+  border: 1px solid var(--background-80);
+  margin: 2em 2em 12em 2em;
+  min-width: 18em;
+}
 
 .main-btn {
   display: inline-block;

--- a/source/components/OrganizationInviteUser.vue
+++ b/source/components/OrganizationInviteUser.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="OrganizationInviteUser">
+  <div class="page-container">
 
     <Notices></Notices>
 
@@ -136,80 +136,69 @@ export default {
 }
 </script>
 <style lang="scss">
- .OrganizationInviteUser {
-  height: 100%;
-  margin: 2em 10em;
-  width: calc(100% - 20em);
-  top: 80px;
-  position: relative;
- }
 
-div.page-inset {
-  background: var(--surface);
-  padding: 2em 6em;
-  border-radius: 1em;
-  border: 1px solid var(--background-80);
-  margin: 2em;
-  min-width: 18em;
-}
+  div.page-inset {
+    padding: 2em 6em;
+  }
 
-div.action-row {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-}
+  div.action-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
 
-div.form-input {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 1em;
+  div.form-input {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1em;
 
-  label, div.label-with-error {
+    label, div.label-with-error {
+      margin-bottom: 0.5em;
+    }
+
+  }
+
+  .form-error {
+    color: var(--error);
+    margin-left: 0.5em;
+  }
+
+  .form-error::before {
+    content: '* ';
+  }
+
+  span.section {
     margin-bottom: 0.5em;
+    display: inline-block;
   }
 
-}
+  div.radio-group {
+    flex-direction: row;
+    align-content: flex-start;
+    flex-wrap: wrap;
+    max-width: 26em;
 
-.form-error {
-  color: var(--error);
-  margin-left: 0.5em;
-}
-
-.form-error::before {
-  content: '* ';
-}
-
-span.section {
-  margin-bottom: 0.5em;
-  display: inline-block;
-}
-
-div.radio-group {
-  flex-direction: row;
-  align-content: flex-start;
-  flex-wrap: wrap;
-
-  input {
-    margin-right: 1em;
-    border: 0px;
-    width: 1.25em;
-    height: 1.25em;
+    input {
+      margin-right: 1em;
+      border: 0px;
+      width: 1.25em;
+      height: 1.25em;
+    }
   }
-}
 
-div.radio-group > .help {
-  margin-block-end: 1em;
-  margin-left: 2.25em;
-  color: var(--on-surface-secondary);
-}
+  div.radio-group > .help {
+    margin-block-end: 1em;
+    margin-left: 2.25em;
+    color: var(--on-surface-secondary);
+  }
 
-.full-width {
-  width: 100%;
-}
+  .full-width {
+    width: 100%;
+  }
 
- table.organization-users {
-  width: 100%;
-  margin-block: 3em;
-}
+   table.organization-users {
+    width: 100%;
+    margin-block: 3em;
+  }
 
 </style>

--- a/source/components/OrganizationSettings.vue
+++ b/source/components/OrganizationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="OrganizationSettings">
+  <div class="page-container">
 
     <div class="breadcrumb">
       <span class="history"><a href="/settings">Settings</a></span>
@@ -10,7 +10,7 @@
     </div>
 
     <div class="page-inset">
-      <h1>{{ organization.name }} | Users And Roles</h1>
+      <h2>{{ organization.name }} | Users And Roles</h2>
 
   <!--
       <form id="editOrgForm">
@@ -167,36 +167,20 @@ export default {
 }
 </script>
 <style lang="scss">
- .OrganizationSettings {
-  height: 100%;
-  margin: 2em;
-  width: calc(100% - 4em);
-  top: 80px;
-  position: relative;
- }
 
-div.page-inset {
-  background: var(--surface);
-  padding: 2em 3em;
-  border-radius: 1em;
-  border: 1px solid var(--background-80);
-  margin: 2em;
-  min-width: 18em;
-}
+  div.action-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
 
-div.action-row {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-}
+  table.organization-users {
+    width: 100%;
+    margin-block: 3em;
+  }
 
-table.organization-users {
-  width: 100%;
-  margin-block: 3em;
-}
-
-span.admin {
-  font-weight: bold;
-}
+  span.admin {
+    font-weight: bold;
+  }
 
 </style>

--- a/source/components/Settings.vue
+++ b/source/components/Settings.vue
@@ -1,27 +1,47 @@
 <template>
   <!-- <super-bar></super-bar> -->
-  <div class="SettingsContainer">
-    <h2>Account Settings</h2>
-    <br/>
-    <a href="/changepassword">Change password</a><br />
-    <a href="/signout">Sign out</a><br>
-    <div class="section">
-      <OrganizationsManager></OrganizationsManager>
+  <div class="page-container">
+
+
+    <!-- TODO make this a component and pass the items as props -->
+    <!-- Once it's a component, spruce up the styling -->
+    <div class="breadcrumb">
+      <span class="history">Accounts</span>
+      <span class="spacer">></span>
+
+      <span class="history">{{ this.$store.state.user.name }}</span>
+      <span class="spacer">></span>
+
+      <span class="active"><strong>Account Settings</strong></span>
     </div>
-    <div class="section">
-      <CredentialsVault></CredentialsVault>
+
+    <div class="page-inset">
+
+      <h2>Account Settings</h2>
+
+      <a href="/changepassword">Change password</a><br />
+      <a href="/signout">Sign out</a><br>
+      <div class="section">
+        <OrganizationsManager></OrganizationsManager>
+      </div>
+      <div class="section">
+        <CredentialsVault></CredentialsVault>
+      </div>
     </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
-  .SettingsContainer {
-    padding: calc(80px + 3.625em + 1px + 1em) 4em 4em 4em;
-  }
 
   .section {
     margin-top: 4em;      
   }
+
+  .section:last-child {
+    margin-bottom: 4em;
+  }
+
+
 </style>
 
 <script>

--- a/source/components/builderv2/CredentialsVault.vue
+++ b/source/components/builderv2/CredentialsVault.vue
@@ -72,7 +72,7 @@
     <p>
       <button class="button-medium" @click="addNew">Add New Credentials</button>
     </p>
-    <table class="credential-sets">
+    <table class="spaced">
       <thead>
         <tr>
           <th class="name">Name</th>
@@ -98,57 +98,5 @@
 </template>
 
 <style lang="scss" scoped>
-  .vault-body {
 
-    .credential-sets {
-      width: 100%;
-      border-collapse: collapse;
-      font-weight: inherit;
-
-      thead th {
-        margin: 0;
-        padding: 0.25rem 0.5rem;
-        font-size: 1.25em;
-        font-weight: bold;
-        border-bottom: 1px solid var(--on-background);
-        text-align: left;
-
-        &.name { width: 40%; }
-        &.credential-type { width: 20%; }
-        &.owner { width: 20%; }
-        &.actions { width: 20%; }
-      }
-
-      tbody {
-        tr:nth-child(even) {
-          background-color: var(--on-background-20);
-        }
-
-        tr:hover {
-          background-color: var(--primary);
-
-          td {
-            color: var(--on-primary);
-
-            &.actions button {
-              visibility: visible;
-            }
-          }
-        }
-
-        td {
-          margin: 0;
-          padding: 0.25em 0.5em;
-
-          &.actions button {
-            text-transform: none;
-            background-color: transparent;
-            color: inherit;
-            border: 1px solid var(--on-primary);
-            visibility: hidden;
-          }
-        }
-      }
-    }
-  }
 </style>

--- a/source/components/builderv2/OrganizationsManager.vue
+++ b/source/components/builderv2/OrganizationsManager.vue
@@ -87,13 +87,11 @@ export default {
         <button class="button-medium" @click="newOrganization">Add New Organization</button>
       </form>
     </span>
-    <table class="organization-sets">
+    <table class="spaced">
         <thead>
             <tr>
                 <th class="name">Name</th>
                 <th class="billing-email">Billing Email</th>
-                <th class="remove"></th>
-                <th class="users"></th>
             </tr>
         </thead>
         <tbody>
@@ -108,55 +106,6 @@ export default {
   
 </template>
 <style lang="scss" scoped>
-.organization-sets {
-    width: 100%;
-    border-collapse: collapse;
-    font-weight: inherit;
-
-    thead th {
-        margin: 0;
-        padding: 0.25rem 0.5rem;
-        font-size: 1.25em;
-        font-weight: bold;
-        border-bottom: 1px solid var(--on-background);
-        text-align: left;
-
-        &.id { width: 10%; }
-        &.name { width: 20%; }
-        &.billing-email { width: 30%; }
-        &.remove { width: 10%; }
-        &.users { width: 40%; }
-    }
-
-    tbody {
-        tr{
-            cursor: pointer;
-        }
-
-        tr:nth-child(even) {
-          background-color: var(--on-background-20);
-        }
-
-        tr:hover {
-          background-color: var(--primary);
-
-          td {
-            color: var(--on-primary);
-          }
-        }
-
-
-        td {
-          margin: 0;
-          padding: 0.25em 0.5em;
-        }
-
-        td .remove-organization:hover{
-            background-color: var(--primary);
-            color: var(--on-primary);
-        }
-      }
-}
 
 #messages{
     margin: 2rem 0;


### PR DESCRIPTION
Note: This PR begins to break an anti-pattern that's cropped up of having page styles repeated in many top-level components. We can now use global `page-container` and `page-inset` classes, and should transition to them wherever possible. This is also true for table styling, which should all use the global `spaced` class, which will continue to be refined over time.

**Before**
Elements sit directly on the background color, old table styles, no breadcrumb

![Screenshot 2023-12-21 at 2 59 36 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/dbba26d7-ba5d-4ff0-a72d-3d541d40ee13)

**After**
Using the new page inset and table styles, breadcrumb placeholder is temped to confirm consistent layout.
![Screenshot 2023-12-21 at 2 54 09 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/3b31169e-0f1d-4859-bb08-dc8e1506b5e3)