### PR TITLE
cleanup/user_id

### DIFF
--- a/source/components/builderv2/EditorConfig.vue
+++ b/source/components/builderv2/EditorConfig.vue
@@ -75,7 +75,7 @@
 
       credentialsEditable() {
         if (this.playgroundMode) { return true }
-        return this.$store.state.manifest.user_id == this.$store.state.user.id
+        return this.$store.state.manifest.owner_id == this.$store.state.user.id
       }
 
     }


### PR DESCRIPTION
**Before**
Ownership check for credential editing permissions was made using `manifest.user_id` which was invalidated by a change to `trivial-api` that moved ownership to a polymorphic design

**After**
The check is made against `manifest.owner_id` instead

**Notes**
This is a temporary fix until the permissions system currently implemented in `trivial-api` is more tightly integrated with `trivial-ui`
Future solutions for permissions checks should rely on that instead of direct ownership checks