### PR TITLE
Fix for ensuring saveCredentials() doesn't run all the time

### DIFF
--- a/source/store/index.js
+++ b/source/store/index.js
@@ -36,6 +36,7 @@ const store = createStore({
     tourMode: false,
     tourStep: 0,
     tourSteps: ['action-info', 'credentials', 'transform-config'],
+    enableSaveCredentials: false
   },
 
   getters: {
@@ -417,6 +418,7 @@ const store = createStore({
     },
 
     async saveCredentials({ state, dispatch }) {
+      console.log(state.credentialSets, state.credentials)
       await fetchJSON('/proxy/trivial', {
         method: 'put',
         headers: {'content-type': 'application/json'},
@@ -443,9 +445,11 @@ const store = createStore({
       return manifest
     },
 
-    async save({ dispatch }) {
+    async save({state, dispatch }) {
       await dispatch('saveManifest')
-      await dispatch('saveCredentials')
+      if(state.enableSaveCredentials){
+        await dispatch('saveCredentials')
+      }
     },
 
     async build({ state }) {
@@ -576,6 +580,7 @@ const store = createStore({
     },
 
     async saveCredentialSet({ commit }, { credential_set, credentials }) {
+      console.log(credential_set,credentials)
       let newCreds = null
       if (credential_set.id) {
         newCreds = await fetchJSON('/proxy/trivial', {

--- a/source/store/index.js
+++ b/source/store/index.js
@@ -418,7 +418,6 @@ const store = createStore({
     },
 
     async saveCredentials({ state, dispatch }) {
-      console.log(state.credentialSets, state.credentials)
       await fetchJSON('/proxy/trivial', {
         method: 'put',
         headers: {'content-type': 'application/json'},
@@ -580,7 +579,6 @@ const store = createStore({
     },
 
     async saveCredentialSet({ commit }, { credential_set, credentials }) {
-      console.log(credential_set,credentials)
       let newCreds = null
       if (credential_set.id) {
         newCreds = await fetchJSON('/proxy/trivial', {


### PR DESCRIPTION
#59 
Before
Saving an app when `LAMBDA_POLICY_ARN` env var is omitted or incorrect leads to apps without credentials to receive  the following error: `Failed to build application: LAMBDA_POLICY_ARN not set`. 
After
This PR introduces a fix that adds a boolean variable in store that enables the savingCredentials() function in store/index.js file. This variable is set to false and will skip saving of credentials.