### PR TITLE
update/recovery_redirect_url

### DIFF
--- a/source/components/RecoverPassword.vue
+++ b/source/components/RecoverPassword.vue
@@ -93,7 +93,7 @@ export default {
           body: JSON.stringify({
             path: "/auth/password",
             email,
-            redirect_url: "https://www.trivialapps.io/resetpassword",
+            redirect_url: `${window.location.origin}/resetpassword`,
           }),
         });
         this.message = `An email has been sent to ${email} with instructions on how to reset the password.`;


### PR DESCRIPTION
**Before**
`redirect_url` was hard-coded to a specific base front-end URL

**After**
`redirect_url` is dynamically generated from the window context

**Notes**
`window.location.origin` should match to the `TRIVIAL_UI_URL` env variable. This variable could be passed into the component instead if this fix is found to be unstable.
fixes #55 