### PR TITLE
update/lupin_url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,9 @@ PORT=3000
 # Prefix added to lambda function names. This must match the settings of the environment you deploy to. For staging, this must be blank.
 # LAMBDA_PREFIX=
 #
-# Set the URL of the server for generated links. The default attempts to guess based on the incoming request:
-# LUPIN_URL=http://localhost:3000
+# Set the URL of the server for generated links. 
+# This variable is used by trivial-core and the default attempts to guess a url based on the incoming request:
+# TRIVIAL_UI_URL=http://127.0.0.1:3000
 #
 # Set the following to match REDIS_URL of trivial-api-staging for webhook data updates. Or set it to your local redis instance if you have a local API server running with redis:
 # REDIS_URL=redis://localhost:6379/1

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "socksjs": "^0.5.0",
         "sql-formatter": "^12.1.2",
         "svg-url-loader": "^8.0.0",
-        "trivial-core": "^1.3.3",
+        "trivial-core": "^1.6.0",
         "type-is": "^1.6.18",
         "url": "^0.11.0",
         "vue": "^3.2.0",
@@ -13128,9 +13128,9 @@
       }
     },
     "node_modules/trivial-core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/trivial-core/-/trivial-core-1.3.3.tgz",
-      "integrity": "sha512-LqyLI9Gdtg4p+txupAdlW+SRvU2i+LHha+i3YOedSw2H2aC51ljgz1EJeNJMElJ4QG2WqEGB2/wZ9uFQWpXvAQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/trivial-core/-/trivial-core-1.6.0.tgz",
+      "integrity": "sha512-wjnfBA/lizWbCdL1JmA0IA/QgNQUeytwuFSoLwYxwTWLJyIBV9wRKx+T6BVdI+JttSGg8QLLWHpaJrILeBt4NA==",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",
         "@aws-sdk/client-elastic-load-balancing-v2": "^3.27.0",
@@ -24730,9 +24730,9 @@
       "dev": true
     },
     "trivial-core": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/trivial-core/-/trivial-core-1.3.3.tgz",
-      "integrity": "sha512-LqyLI9Gdtg4p+txupAdlW+SRvU2i+LHha+i3YOedSw2H2aC51ljgz1EJeNJMElJ4QG2WqEGB2/wZ9uFQWpXvAQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/trivial-core/-/trivial-core-1.6.0.tgz",
+      "integrity": "sha512-wjnfBA/lizWbCdL1JmA0IA/QgNQUeytwuFSoLwYxwTWLJyIBV9wRKx+T6BVdI+JttSGg8QLLWHpaJrILeBt4NA==",
       "requires": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",
         "@aws-sdk/client-elastic-load-balancing-v2": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "socksjs": "^0.5.0",
     "sql-formatter": "^12.1.2",
     "svg-url-loader": "^8.0.0",
-    "trivial-core": "^1.3.3",
+    "trivial-core": "^1.6.0",
     "type-is": "^1.6.18",
     "url": "^0.11.0",
     "vue": "^3.2.0",


### PR DESCRIPTION
**Before**
.env used `LUPIN_URL` to specify the base front-end URL

**After**
.env uses `TRIVIAL_UI_URL` instead

**Notes**
This variable is currently only used by `trivial-core` and relies on https://github.com/solid-adventure/trivial-core/pull/27
`trivial-core` version must be `^1.6.0`
fixes #27 