### PR TITLE
Feature/provided panels

### DIFF
--- a/source/components/panels/Dashboard.vue
+++ b/source/components/panels/Dashboard.vue
@@ -46,6 +46,7 @@
 
   // Panels
   import Headline from './Headline.vue'
+  import HeadlineTable from './HeadlineTable.vue'
   import LineChart from './LineChart.vue'
   import notifications from '../notifications'
   import Section from './Section.vue'
@@ -63,6 +64,7 @@
       // Panels
       DatePicker,
       Headline,
+      HeadlineTable,
       LineChart,
       Section,
       Spreadsheet,

--- a/source/components/panels/DashboardSettings.vue
+++ b/source/components/panels/DashboardSettings.vue
@@ -87,7 +87,8 @@
 
       timezone(newVal) {
         this.saveOptionAttribute("timezone", newVal)
-      }
+      },
+
     },
 
     computed: {

--- a/source/components/panels/HeadlineTable.vue
+++ b/source/components/panels/HeadlineTable.vue
@@ -4,10 +4,19 @@
       <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" />
       <h2 v-if="cascadingTitle">{{cascadingTitle}}</h2>
       <p v-if="cascadingDescription">{{cascadingDescription}}</p>
-      <h1>
-        {{formattedCount}}
-      </h1>
-        <p>{{errors}}</p>
+
+      <table v-if="Object.entries(formattedCounts).length > 0">
+        <tr v-for="(value, key) in formattedCounts">
+          <td>{{ key }}</td>
+          <td>{{ value }}</td>
+        </tr>
+      </table>
+      <table v-else>
+        <tr>
+          <td>No results</td>
+        </tr>
+      </table>
+      <p>{{errors}}</p>
     </div>
   </div>
 </template>
@@ -21,16 +30,23 @@
     mixins: [PanelBase],
 
     computed: {
-      formattedCount() {
+
+      formattedCounts() {
+        if (typeof(this.count) !== 'object') { return {} }
+        let out = {}
         try {
           let options = this.app.panels.options.countFormat || {}
-          // countFormat: {type: "money", args: {places: 0}}
-          let args = [this.count, Object.values(options.args)].flat()
-          return Format[options.type](...args)
-        } catch(e) {
+          for (const [k, v] of Object.entries(this.count)) {
+            let args = [v, Object.values(options.args)].flat()
+            out[k] = `${Format[options.type](...args)}`
+          }
+          return out
+        }
+        catch (e) {
           return this.count
         }
-      }
+      },
+
     },
 
     methods: {
@@ -45,7 +61,7 @@
             this.title = r.title
           } catch (error) {
             this.errors = error
-          }          
+          }
         }
       }
     }

--- a/source/components/panels/HeadlineTable.vue
+++ b/source/components/panels/HeadlineTable.vue
@@ -8,8 +8,14 @@
       <table v-if="Object.entries(formattedCounts).length > 0">
         <tr v-for="(value, key) in formattedCounts">
           <td>{{ key }}</td>
-          <td>{{ value }}</td>
+          <td class="value">{{ value }}</td>
         </tr>
+        <tr v-if="displayTotal">
+          <td class="total total_label">Total</td>
+          <td class="total value">{{ formattedTotal }}</td>
+        </tr>
+
+
       </table>
       <table v-else>
         <tr>
@@ -30,6 +36,35 @@
     mixins: [PanelBase],
 
     computed: {
+
+      displayTotal() {
+        try {
+          return this.app.panels.options.display_total || false
+        } catch (error) {
+          return false
+        }
+      },
+
+      total() {
+        if (!this.count) { return 0 }
+        try {
+          return Object.values(this.count).reduce((acc, curr) => acc + Number(curr), 0);
+        } catch (error) {
+          return 0
+        }
+      },
+
+      formattedTotal() {
+        if (typeof(this.count) !== 'object') { return {} }
+        try {
+          let options = this.app.panels.options.countFormat || {}
+          let args = [this.total, Object.values(options.args)].flat()
+          return `${Format[options.type](...args)}`
+        }
+        catch (e) {
+          return this.total
+        }
+      },
 
       formattedCounts() {
         if (typeof(this.count) !== 'object') { return {} }
@@ -79,5 +114,19 @@
     flex-direction: column;
     justify-content: center;
   }
+
+  td.value {
+    text-align: right;
+  }
+
+  td.total {
+    border-top: 1px solid var(--input-border-color);
+  }
+
+  td.total_label {
+    padding-right: 1em;
+    text-align: right;
+  }
+
 
 </style>

--- a/source/components/panels/PanelBase.vue
+++ b/source/components/panels/PanelBase.vue
@@ -226,13 +226,18 @@
               ),
             headers: {'content-type': 'application/json'}
           })
-          // TODO: Pre-process the response to wrap in the {statusCode: xxx, body: xxx} format
+          .then(response => this.preProcessResponse(response, 200))
           .then(response => this.handleResponse(response))
         } catch (error) {
           this.errors = error
+          this.preProcessResponse(error, 500)
           console.error('[fetchDataTrivialApi] Error:', error)
         }
         this.loading = false
+      },
+
+      preProcessResponse(response, status) {
+        return {statusCode: status, body: response}
       },
 
       fetchDataTrivialApp() {

--- a/source/components/panels/PanelBase.vue
+++ b/source/components/panels/PanelBase.vue
@@ -207,7 +207,7 @@
       //       "type": "trivial-api",
       //       "args": {
       //         "path": "reports/item_count",
-      //         "register_id": 1
+      //         "register_ids": 1
       //       }
       //     }
       //   },

--- a/source/components/panels/PanelBase.vue
+++ b/source/components/panels/PanelBase.vue
@@ -83,6 +83,33 @@
         return new URL(path, `https://${this.app.hostname}.${this.app.domain}`).href
       },
 
+      data_source() {
+        if (!this.app) { return }
+        try {
+          if (this.app.panels.options.data_source.type === 'trivial-api')  {
+            return 'trivial-api'
+          } else {
+            return 'trivial-app'
+          }
+        } catch (e) {
+          return 'trivial-app'
+        }
+      },
+
+      reportPath() {
+        if (!this.app) { return }
+        return this.app.panels.options.data_source.args.path
+      },
+
+      data_sourceArgs() {
+        if (!this.app) { return }
+        try {
+          return this.app.panels.options.data_source.args
+        } catch (e) {
+          return {}
+        }
+      },
+
       customerToken() {
         return this.$store.state.user.current_customer_token
       },
@@ -134,9 +161,11 @@
 
       },
 
-      // As a computed property, this misses changes to the Mixin children
+      // This is a method because, as a computed property, it misses changes to the Mixin children
       mergedOptions() {
-        return Object.assign({customer_token: this.customerToken}, this.options)
+        let out = Object.assign({customer_token: this.customerToken}, this.options)
+        out = Object.assign(out, this.data_sourceArgs)
+        return out
       },
 
       intialData() {
@@ -163,12 +192,55 @@
 
       async fetchData() {
         if (!this.app) { return }
+        if (this.data_source === 'trivial-api') {
+          this.fetchDataTrivialApi()
+        } else {
+          this.fetchDataTrivialApp()
+        }
+      },
+
+      // Expected format:
+      // {
+      //   "options": {
+      //     "full_width": false,
+      //     "data_source": {
+      //       "type": "trivial-api",
+      //       "args": {
+      //         "path": "reports/item_count",
+      //         "register_id": 1
+      //       }
+      //     }
+      //   },
+      //   "component": "Headline"
+      // }
+      async fetchDataTrivialApi(displayLoading=true) {
+        if (displayLoading) { this.loading = true }
+        try {
+          await fetchJSON(`/proxy/trivial`, {
+            method: 'post',
+            body: JSON.stringify(
+              Object.assign(
+                this.mergedOptions(),
+                {path: this.reportPath}
+                )
+              ),
+            headers: {'content-type': 'application/json'}
+          })
+          // TODO: Pre-process the response to wrap in the {statusCode: xxx, body: xxx} format
+          .then(response => this.handleResponse(response))
+        } catch (error) {
+          this.errors = error
+          console.error('[fetchDataTrivialApi] Error:', error)
+        }
+        this.loading = false
+      },
+
+      fetchDataTrivialApp() {
         if (this.shouldFetchCached) {
           this.fetchDataCached()
         } else {
           this.fetchDataLive()
         }
-
       },
 
       async fetchDataLive(displayLoading=true) {


### PR DESCRIPTION
**Before**
- Panels fetch data from their lambda, no matter what.
- Errors are not displayed on Headline panels
- There isn't a simple way to display a small/medium summary of key/value pairs

**After**
- Panels can fetch data from their lambda OR trivial-api, by setting the "data_source" panel option to "trivial-api". If no value is provided, they will fetch from the lambda (original behavior by default)
- Errors are displayed on Headline panels, if they exist
- New panel type "HeadlineTable"
<img width="1272" alt="Screenshot 2024-02-03 at 4 30 25 PM" src="https://github.com/solid-adventure/trivial-ui/assets/80924/682e83d8-401e-4aa6-b51e-8c84e801e2fb">




**Testing**

Relies on https://github.com/solid-adventure/trivial-api/pull/226
Add a panel to a dashboard and set it's panel options manually.

With formatting and new "display_total" option:
```json
{
  "options": {
    "title": "Sum, Group by Register",
    "full_width": false,
    "countFormat": {
      "args": {
        "places": 2
      },
      "type": "money"
    },
    "data_source": {
      "args": {
        "path": "reports/item_sum",
        "group_by": [
          "register_id"
        ]
      },
      "type": "trivial-api"
    },
    "display_total": true
  },
  "component": "HeadlineTable"
}
```
<img width="842" alt="Screenshot 2024-02-04 at 1 42 25 PM" src="https://github.com/solid-adventure/trivial-ui/assets/80924/531c85e1-76fd-4e7b-8ed0-adc3e4a2d3b8">

