### PR TITLE
simple env var passing

### DIFF
--- a/source/store/index.js
+++ b/source/store/index.js
@@ -234,6 +234,7 @@ const store = createStore({
 
   actions: {
     async init({ commit, dispatch, state }, { appId }) {
+      console.log(VUE_APP_SAMPLE)
       try {
         await dispatch('loadProfile')
         await dispatch('loadResources', { dispatch, router })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
     new MiniCssExtractPlugin(),
     new webpack.DefinePlugin(
     {
+      VUE_APP_SAMPLE: JSON.stringify(process.env.VUE_APP_SAMPLE),
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: !isDevelopment,
     }),


### PR DESCRIPTION
In .env, I've added the var as:

`VUE_APP_SAMPLE="yeah"`

And when the app loads, you can see the contents are available:
![Screenshot 2024-02-05 at 9 42 02 AM](https://github.com/solid-adventure/trivial-ui/assets/80924/a50ba0e0-28fe-48cb-9726-df09c7edf270)

I don't think the `VUE_APP_` prefix is strictly necessary, but we'll be closer to ready when we do migrate to vue-cli later.