### PR TITLE
First draft of disabling SaveCredentials per env var

### DIFF
--- a/source/store/index.js
+++ b/source/store/index.js
@@ -36,6 +36,7 @@ const store = createStore({
     tourMode: false,
     tourStep: 0,
     tourSteps: ['action-info', 'credentials', 'transform-config'],
+    enableSaveCredentials: VUE_APP_ENABLE_SAVE_CREDENTIALS
   },
 
   getters: {
@@ -445,7 +446,9 @@ const store = createStore({
 
     async save({ dispatch }) {
       await dispatch('saveManifest')
-      await dispatch('saveCredentials')
+      if(this.state.enableSaveCredentials){
+        await dispatch('saveCredentials')
+      }
     },
 
     async build({ state }) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const webpack = require('webpack');
 const mode =
   process.env["NODE_ENV"] === "production" ? "production" : "development";
 const isDevelopment = mode == "development";
+const enableSaveCredentials = process.env.VUE_APP_ENABLE_SAVE_CREDENTIALS;
 
 module.exports = {
   devtool: "inline-source-map",
@@ -54,6 +55,7 @@ module.exports = {
     new MiniCssExtractPlugin(),
     new webpack.DefinePlugin(
     {
+      VUE_APP_ENABLE_SAVE_CREDENTIALS: (enableSaveCredentials?enableSaveCredentials:false),
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: !isDevelopment,
     }),


### PR DESCRIPTION
#59 

Before
Saving an app when `LAMBDA_POLICY_ARN` env var is omitted or incorrect leads to apps without credentials to receive the following error: Failed to build application: `LAMBDA_POLICY_ARN` not set.
After
This PR introduces a fix that adds a boolean variable in store that enables the `savingCredentials()` function in store/index.js file. This variable is set to false and will skip saving of credentials.