### PR TITLE
update/invitations_url

### DIFF
--- a/source/components/OrganizationInviteUser.vue
+++ b/source/components/OrganizationInviteUser.vue
@@ -96,6 +96,7 @@ export default {
         path: `/auth/invitation`,
         email: this.newUserEmail,
         name: this.newUserName,
+        trivial_ui_url: window.location.origin,
         invitation_metadata: {
           org_id: this.orgId,
           role: this.newUserRole


### PR DESCRIPTION
**Before**
no url was passed to back-end api for invitation emails and a back-end ENV variable was used instead

**After**
`trivial_ui_url` passed to back-end with POST request for user invitations

**Notes**
- Relies on https://github.com/solid-adventure/trivial-api/pull/232