### PR TITLE
fix/auth_page_height

### DIFF
--- a/source/assets/stylesheets/includes/_auth.scss
+++ b/source/assets/stylesheets/includes/_auth.scss
@@ -1,5 +1,5 @@
 .overlay {
-    height: 100%;
+    height: calc(100% - 80px);
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/source/components/AcceptInvitation.vue
+++ b/source/components/AcceptInvitation.vue
@@ -68,9 +68,9 @@
                     </div>
                     <div v-else>
                       <ActionButton class = "button-small submit" :action="handleSubmit" value ="Submit" working-value="Updating..." :disabled="!isPasswordValid"></ActionButton>
-                      <span>
+                      <p>
                         Already have an account? <a href="/" @click.prevent="handleExistingUserClick" >Sign in</a>
-                      </span>
+                      </p>
                     </div>
     	        </form>
             </span>

--- a/source/components/Register.vue
+++ b/source/components/Register.vue
@@ -130,12 +130,7 @@
   align-content: space-between;
 
 }
-.overlay.clearSuperBar {
-  margin-top: 20px;
-}
-
 .container {
-  padding: 2em;
   width: unset;
 }
 


### PR DESCRIPTION
Auth pages currenlty have a height of 100%+80px due to the clearSuperBar present in all pages. This causes every auth page to be off centered when the pages loads and it also introduces an unnecessary side scroll.