### PR TITLE
correctly wrap payload object

### DIFF
--- a/src/components/builderv2/AppTrigger.vue
+++ b/src/components/builderv2/AppTrigger.vue
@@ -111,7 +111,7 @@
       async sendCustom() {
         try {
           const appId = this.app.name
-          await this.$store.state.Session.apiCall(`/webhooks/${appId}/send`, 'POST', JSON.parse(this.customPayload))
+          await this.$store.state.Session.apiCall(`/webhooks/${appId}/send`, 'POST', {payload: JSON.parse(this.customPayload)})
           Notifications.success('Data sent')
         } catch (err) {
           console.error('Failed to send custom data', err)


### PR DESCRIPTION
**Before**
App Trigger sends null payloads, regardless of UI values
![Screenshot 2024-03-14 at 3 52 43 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/6f7f9124-64d9-4f67-b464-c4c06fb31c6f)

![screenshot_2024-03-14_at_3 34 18_pm_480](https://github.com/solid-adventure/trivial-ui/assets/80924/1a1dcea0-6600-4eac-8a3d-b50594ee2189)

**After**
Payload is passed through as expected (screenshot is from Cloudwatch, since ActivityEntry is not available on dev
![Screenshot 2024-03-14 at 3 53 09 PM](https://github.com/solid-adventure/trivial-ui/assets/80924/2360c9bd-edb9-430a-8bf4-7ec2429ab0e1)
