### PR TITLE
pre work for container-level vars

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
 </head>
 
 <body>
+  <script type="text/javascript">
+    // CONTAINER_INJECTION_TARGET
+  </script>
   <div id="app">
     <router-view></router-view>
   </div>

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -6,7 +6,8 @@ export default class Session {
   }
 
   static apiUrl(path) {
-    return new URL(path, store.state.trivialApiUrl)
+    const TRIVIAL_API_URL = window.CONTAINER_TRIVIAL_API_URL || import.meta.env.VITE_TRIVIAL_API_URL || 'trivial-api-url-not-set'
+    return new URL(path, TRIVIAL_API_URL)
   }
 
   static async apiCall(path, method='GET', data) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -40,7 +40,6 @@ const store = createStore({
     tourSteps: ['action-info', 'credentials', 'transform-config'],
     enableSaveCredentials: import.meta.env.VITE_ENABLE_SAVE_CREDENTIALS,
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
-    trivialApiUrl: import.meta.env.VITE_TRIVIAL_API_URL,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
   },


### PR DESCRIPTION
**Before**
The only way to set `TRIVIAL_API_URL` is with Vite, which is problematic for build pipelines. Because the slug is built in a lower environment and later promoted without changes, the env vars become cross-contaminated.

**After**
There is a target on index.html that can be leveraged to write `CONTAINER_TRIVIAL_API_URL ` when the container is started. If the value is present, it is used, and falls back to the `VITE_TRIVIAL_API_URL ` version to conveniently support both local development and production deployment.

This is the pre-work to support writing to the `CONTAINER_` var, but does not yet leverage it.