### PR TITLE
pass manifest to builder instead of fetching

### DIFF
--- a/src/components/InstanceSettings.vue
+++ b/src/components/InstanceSettings.vue
@@ -49,11 +49,10 @@
       <hr class="headroom accent" />
       <h2 class="headroom section-title">Download Source</h2>
       <em class="section-help-text">Download the compiled source code for this app.</em>
-      <br/>
-      <div>
-        <a class="button-small" :href="downloadLink" download>Download</a>
-      </div>
+      <div class="error">{{downloadMessage}}</div>
 
+      <br/>
+      <a class="button-small" href="#" @click.prevent="handleDownload">Download</a>
       <hr class="headroom accent" />
       <h2 class="headroom section-title">UI Panel Options</h2>
       <p class="section-help-text"><em>Danger zone! Editing the panel settings directly allows you to break how your app renders.</em></p>
@@ -158,6 +157,10 @@
     padding-bottom: 4em;
   }
 
+  .error {
+    color: var(--error);
+  }
+
   .row {
     display: flex;
     align-content: flex-start;
@@ -210,6 +213,7 @@
         rebuilding: false,
         updatingPanels: false,
         updatingSchedule: false,
+        downloadMessage: '',
         message: null,
         errorMessage: null,
         manifestContent: {},
@@ -339,6 +343,38 @@
           console.log('[InstanceSetings][loadManifest] Error:', error)
           this.errorMessage = error.message
         }
+      },
+
+      handleDownload() {
+        this.downloadMessage = ''
+        fetch(this.downloadLink, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({manifest: this.manifest})
+        })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error('Failed to download')
+          }
+          return response
+        })
+        .then(response => response.blob())
+        .then(blob => {
+          const url = window.URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = `${this.appId}.zip`
+          document.body.appendChild(a)
+          a.click()
+          window.URL.revokeObjectURL(url)
+        })
+        .catch(error => {
+          console.log('[InstanceSetings][handleDownload] Error:', error)
+          this.downloadMessage = error.message
+        })
+
       },
 
       updated() {


### PR DESCRIPTION
**Before**
**App -> Settings -> Download Source** fails with 404

```
"Unauthorized","stack":"Error: Unauthorized\n    at APIService._serviceFetch (/Library/WebServer/solid-adventure/trivial-ui/node_modules/trivial-core/lib/APIService.js:29:13)
```

**After**
As long as the express server is running, **App -> Settings -> Download Source** succeeds with 200:ok

```
:"/download/2db45fd4df8738","query":{}
...
"res":{"statusCode":200,"headers":{"x-powered-by":"Express","content-type":"application/zip","content-disposition":"attachment; filename=\"2db45fd4df8738-20240323T213802584Z.zip\"
```
 
Note: This bug is a by-product of removing the proxy. Long term, we want to build apps without the express server at all, but this gets the functionality working until that larger piece of work is done.