### PR TITLE
initial activity search form and query building

### DIFF
--- a/src/components/InstanceSettings.vue
+++ b/src/components/InstanceSettings.vue
@@ -100,7 +100,7 @@
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
   .InstanceSettings {
   	height: 100%;
   	margin: 2em;

--- a/src/components/activityLog/WebhooksTable.vue
+++ b/src/components/activityLog/WebhooksTable.vue
@@ -181,6 +181,7 @@
 </style>
 
 <script>
+import SearchFilter from '../../lib/SearchFilter'
 import TrackingService from '../../../lib/TrackingService'
 import { formatJSON, fetchJSON } from 'trivial-core/lib/component-utils'
 import BuildEventMarker from './BuildEventMarker.vue'
@@ -235,6 +236,16 @@ import { mapState } from 'vuex'
       })
     },
 
+    searchParam() {
+      if (this.$route.query.search) {
+        let filters = JSON.parse(this.$route.query.search)
+        let searchFilter = new SearchFilter(filters, null, null, 'payload')
+        return `&search=${JSON.stringify(searchFilter.searchParams)}`
+      } else {
+        return ''
+      }
+    },
+
     ...mapState([
       'app'
     ])
@@ -253,12 +264,12 @@ import { mapState } from 'vuex'
 
     async fetchData() {
       try {
-        await this.$store.state.Session.apiCall(`/activity_entries?app_id=${this.appId}`)
+        await this.$store.state.Session.apiCall(`/activity_entries?app_id=${this.appId}${this.searchParam}`)
         .then(webhooks => this.webhooks = webhooks)
         .then(webhooks => this.selectFirst(webhooks))
       } catch (error) {
         console.error('[WebhooksTable][fetchData] Error:', error)
-        notifications.error(`Could not load webhooks: ${error.message}`)
+        notifications.error(`Could not load activity: ${error.message}`, {autoDismiss: false})
       }
       this.loading = false
     },

--- a/src/components/builderv2/FilterEditor.vue
+++ b/src/components/builderv2/FilterEditor.vue
@@ -1,0 +1,219 @@
+<script>
+  import SearchFilter from '../../lib/SearchFilter'
+  import Icon from '../Icon.vue'
+
+  export default {
+    components: {
+      Icon
+    },
+
+    data() {
+      return {
+        filters: [],
+        searchFilter: new SearchFilter([]),
+        selectedColumn: null,
+        selectFilterKeys: [],
+        selectedKey: null,
+        selectedName: null,
+        selectedOperator: '=',
+        selectedValue: null,
+        comperators: ['<', '>', '<=', '>=', '=', '<>', '!='],
+        predicates: ['IS NULL','IS NOT NULL','IS TRUE','IS FALSE'],
+        // The API also supports 'IS NOT TRUE', 'IS NOT FALSE'
+        // Technically these could produce results, but they *feel* redundant, and aren't expected to be necesssary
+      }
+    },
+
+    async mounted() {
+      if (this.$route.query.search) {
+        let search = JSON.parse(this.$route.query.search)
+        this.filters = search
+      }
+      this.searchFilter = new SearchFilter(this.filters, this.$store.state.Session, this.$route.params.id, 'payload')
+      await this.searchFilter.setPossibleFilters()
+    },
+
+    watch: {
+      searchParams: function (newVal) {
+        this.$router.push({query: {search: JSON.stringify(this.filters)} })
+      },
+
+      selectedFilter: async function (newVal) {
+        this.selectFilterKeys = await this.searchFilter.getFilterKeys(newVal)
+      }
+
+    },
+
+    methods: {
+      addFilter() {
+         let filter = {
+          column: this.selectedFilter.column,
+          type: this.selectedFilter.type,
+          name: this.selectedName,
+          key: this.selectedKey,
+          operator: this.selectedOperator,
+          value: this.selectedValue
+        }
+        this.filters.push(filter)
+        this.selectedKey = null
+        this.selectedName = null
+        this.selectedOperator = '='
+        this.selectedValue = null
+      },
+
+    },
+
+    computed: {
+
+      selectedFilter() {
+        return this.searchFilter.possibleFilters.find(f => f.name === this.selectedName) || {}
+      },
+
+      selectedFilterRequiresKey() {
+        return this.selectFilterKeys.length > 0
+      },
+
+      selectedFilterKeySatisfied() {
+        if (!this.selectedFilterRequiresKey) return true
+        return this.selectedName !== null && this.selectedKey !== null
+      },
+
+      displayOperatorInput() {
+        return this.selectedName || !this.selectedFilterKeySatisfied
+      },
+
+      displayValueInput() {
+        if (this.selectedFilterRequiresKey && !this.selectedKey) return false
+        if (this.predicates.find(p => p === this.selectedOperator)) return false
+        return this.selectedFilter && this.selectedOperator
+      },
+
+      operators() {
+        return this.comperators.concat(this.predicates)
+      },
+
+      searchParams() {
+        return this.searchFilter.searchParams
+      }
+
+    }
+  }
+
+</script>
+
+<template>
+  <div class="filters-container page-inset">
+    <h2>Filters</h2>
+
+      <!-- Uncomment for easy debugging of queries -->
+      <!-- <pre> searchParam </pre> -->
+      <!-- <pre> {{ searchParams }}</pre> -->
+
+      <!-- FilterRow -->
+      <div class='filter-rows'>
+
+        <div v-if="filters.length === 0">
+          <p>No filters</p>
+        </div>
+
+        <div class='filter-row' v-for="filter of filters">
+          <span>{{ filter.name }} {{ filter.key }} {{ filter.operator }} {{ filter.value }}</span>
+          <span>
+            <button class='remove' @click.prevent="filters.splice(filters.indexOf(filter), 1)">
+              <Icon icon="times-circle"></Icon>
+            </button>
+          </span>
+        </div>
+      </div>
+
+      <!-- New Filter Form -->
+      <div class="form-row">
+        <div class="row-column">
+          <p><label for="filter-name">Filters</label></p>
+          <select v-model="selectedName" class="filter-row">
+            <option v-for="filter of searchFilter.possibleFilters" type="text" id="filter-name" name="filter-name" placeholder="Filter Name">
+              {{ filter.name }}
+            </option>
+          </select>
+        </div>
+
+
+        <!-- If filter requires key  -->
+        <div class="row-column" v-if="selectedFilterRequiresKey">
+          <p><label for="filter-key">Key</label></p>
+          <select v-model="selectedKey" class="filter-row">
+            <option v-for="key of selectFilterKeys" type="text" id="filter-key" name="filter-key" placeholder="Filter Key">
+              {{ key }}
+            </option>
+          </select>
+
+
+        </div>
+
+
+        <div class="row-column" v-if="displayOperatorInput">
+          <p><label for="filter-operator">Match</label></p>
+          <select v-model="selectedOperator" class="filter-row">
+            <option v-for="operator of operators" type="text" id="filter-operator" name="filter-name" placeholder="Filter Name">
+              {{ operator }}
+            </option>
+          </select>
+        </div>
+
+        <!-- If operator requires a value -->
+        <div class="row-column" v-if="displayValueInput">
+          <p><label for="filter-value">Value</label></p>
+          <input type="text" v-model="selectedValue">
+        </div>
+
+
+        <div class="row-column">
+          <button @click.prevent="addFilter" class="button-medium">Add Filter</button>
+        </div>
+
+      </div>
+
+
+
+
+    </div>
+</template>
+
+<style lang="scss" scoped>
+  div.page-inset {
+    margin: 0;
+  }
+
+  .filters-container {
+
+    button.remove {
+      background: none;
+      border: none;
+      color: var(--on-surface);
+      cursor: pointer;
+    }
+
+
+    .hidden {
+      display: none;
+    }
+
+    .form-row {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-end;
+    }
+
+    .row-column {
+      margin-right: 1em;
+    }
+
+    div.filter-row {
+      border: 1px solid #ccc;
+      padding: 1em;
+    }
+
+
+  }
+
+</style>

--- a/src/components/builderv2/InstanceActivity.vue
+++ b/src/components/builderv2/InstanceActivity.vue
@@ -1,11 +1,15 @@
 <script>
-  import WebhooksTable from '../activityLog/WebhooksTable.vue'
+  import FilterEditor from './FilterEditor.vue'
   import NavTree from './NavTree.vue'
+  import Notices from '../Notices.vue'
+  import WebhooksTable from '../activityLog/WebhooksTable.vue'
 
   export default {
     components: {
+      FilterEditor,
+      NavTree,
+      Notices,
       WebhooksTable,
-      'nav-tree': NavTree
     }
   }
 
@@ -14,7 +18,10 @@
 <template>
   <div class="InstanceActivity">
     <!-- <super-bar></super-bar> -->
+    <Notices></Notices>
     <nav-tree :selected-title="'activity'"></nav-tree>
+
+    <FilterEditor></FilterEditor>
     <WebhooksTable></WebhooksTable>
   </div>
 </template>

--- a/src/lib/SearchFilter.js
+++ b/src/lib/SearchFilter.js
@@ -1,0 +1,144 @@
+export default class SearchFilter {
+  constructor(filters, session, app_id, json_column) {
+    this.filters = filters
+    this.session = session
+    this.app_id = app_id
+    this.json_column = json_column // This is a hack; we allow a single column to target for a JSON search
+    this.possibleFilters = []
+  }
+
+  async setPossibleFilters() {
+    // Populate with all of the first-level keys in the JSON column
+    let keys = await this.session.apiCall(`/activity_entries/keys?col=${this.json_column}&app_id=${this.app_id}`)
+    for (let key of keys) {
+      this.possibleFilters.push({
+        name: key,
+        // requiresKey: true,
+        column: this.json_column,
+        type: 'jsonb'
+      })
+    }
+
+    // Add extra columns of the table itself
+    // TODO, Pass these in from the caller so the class is more flexible
+    this.possibleFilters.push(
+      {
+        name: 'status',
+        requiresKey: false,
+      },
+      // {
+      //   name: 'register_item_id',
+      //   requiresKey: false,
+      // },
+      // {
+      //   name: 'actitivity_type',
+      //   requiresKey: false,
+      // },
+      // {
+      //   name: 'duration_ms',
+      //   requiresKey: false,
+      // },
+      // {
+      //   name: 'created_at',
+      //   requiresKey: false,
+      // },
+      // {
+      //   name: 'updated_at',
+      //   requiresKey: false,
+      // },
+    )
+  }
+
+  async getFilterKeys(filter={}) {
+    if (filter.hasOwnProperty('requiresKey') && !filter.requiresKey) { return [] }
+    if (filter.name === undefined) { return [] }
+    let keys = []
+    try {
+      keys =  await this.session.apiCall(`/activity_entries/keys?col=${this.json_column}&app_id=${this.app_id}&path={${filter.name}}`)
+    } catch (error) {
+      console.log(error)
+    }
+    return keys
+  }
+
+  // c = columnn
+  // o = operator
+  // p = predicate
+  paramsForJSONB(key, groupedFilters) {
+    return {
+        c: key,
+        o: '@@', // Additional JSONB_OPERATORS the API supports: %w[? ?& ?| @> @? @@]
+        p: groupedFilters.map(f => {
+          if (f.operator === '=') { f.operator = '==' }
+          if (f.key) {
+            return `$.${f.name}.${f.key} ${this.jsonPredicateFromOperator(f.operator)} ${f.value || ''}`.trim()
+          } else {
+            return `$.${f.name} ${f.operator} ${f.value || ''}`.trim()
+          }
+        }).join(' && ')
+      }
+  }
+
+  jsonPredicateFromOperator(operator) {
+    switch (operator) {
+    case 'IS NULL':
+      return `== null`
+    case 'IS NOT NULL':
+      return '<> null'
+    case 'IS TRUE':
+      return '== true'
+    case 'IS FALSE':
+      return '== false'
+    default:
+      return operator
+    }
+  }
+
+  paramsForNonJSONB(key, groupedFilters) {
+    let out = []
+    groupedFilters.map(f => {
+      out.push({
+        c: key,
+        o: f.operator,
+        p: f.value?.trim()
+      })
+    })
+    return out
+  }
+
+  get filtersGroupedbyColumn() {
+    let grouped = {}
+    this.filters.forEach(f => {
+      if (f.column) {
+        if (grouped.hasOwnProperty(f.column)) {
+          grouped[f.column].push(f)
+        } else {
+          grouped[f.column] = [f]
+        }
+      } else {
+        if (grouped.hasOwnProperty(f.name)) {
+          grouped[f.name].push(f)
+        } else {
+          grouped[f.name] = [f]
+        }
+      }
+    })
+    return grouped
+  }
+
+  get searchParams() {
+    let search = []
+    for (let key of Object.keys(this.filtersGroupedbyColumn)) {
+      let columnType = this.filtersGroupedbyColumn[key][0]?.type
+      if (columnType === 'jsonb') {
+        // By definition, we get a single object back with conditions stacked into a single predicate
+        search.push(this.paramsForJSONB(key, this.filtersGroupedbyColumn[key]))
+      } else {
+        // With non-jSON columns, we get an array of objects, each with a single predicate
+        search = search.concat(this.paramsForNonJSONB(key, this.filtersGroupedbyColumn[key]))
+      }
+    }
+    return search
+  }
+
+}

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -38,13 +38,14 @@ export default class Session {
     if (text.replaceAll(' ','').length > 0) {
      out = await response.json()
     }
-
     if (response.ok) {
       return out
     } else if (out.error) {
       throw new Error(out.error)
-    } else if (out.errors) {
+    } else if (out.errors && Array.isArray(out.errors)) {
       throw new Error(out.errors.join(', '))
+    } else if (out.errors) {
+      throw new Error(out.errors)
     } else if (response.statusText) {
       throw new Error(response.statusText)
     } else {


### PR DESCRIPTION
**Before**
Activity Log always returns the 100 most recent results

**After**
Activity Log is filterable by `payload` keys and `status`.

Drive-by fixes:
- fetch errors on Activity Log are displayed, and are not red on red
- An API call response with `errors` that is not an array throws with the message as expected
