### PR TITLE
Feature/permissions

### DIFF
--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink v-if= "app?.display" :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if= "app?.canUpdate" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">
@@ -241,7 +241,6 @@
             .filter(app => app.panels)
             .filter(app => app.panels.component.toLowerCase() == this.panelTypeFilter.toLowerCase())
         }
-        this.setPermitsForApps(apps)
         return apps
 
       },
@@ -305,15 +304,6 @@
     },
 
     methods: {
-
-      setPermitsForApps(apps){
-        apps.map(app => {
-          return this.Permissions.can('update', 'App', { appName: app.name })
-            .then(res => {
-              app.display = res;
-            });
-        });   
-      },
 
       editLink(app) {
         if (app.panels && app.panels.component == 'Dashboard') {

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -199,7 +199,6 @@
         chartType: 'hourly',
         searchTerm: '',
         panelTypeFilter: null,
-        shouldRenderEdit: false
         // panelTypeGroups: [
         //   {name: 'Dashboards', filter: 'Dashboard'},
         //   // {name: 'Workbooks', filter: 'Workbook'},

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink v-if= "Permissions.can('update', 'App', {appName:app.name})" :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if= "app?.display" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">
@@ -198,7 +198,8 @@
         sortAsc: true,
         chartType: 'hourly',
         searchTerm: '',
-        panelTypeFilter: null
+        panelTypeFilter: null,
+        shouldRenderEdit: false
         // panelTypeGroups: [
         //   {name: 'Dashboards', filter: 'Dashboard'},
         //   // {name: 'Workbooks', filter: 'Workbook'},
@@ -240,6 +241,7 @@
             .filter(app => app.panels)
             .filter(app => app.panels.component.toLowerCase() == this.panelTypeFilter.toLowerCase())
         }
+        this.setPermitsForApps(apps)
         return apps
 
       },
@@ -303,6 +305,15 @@
     },
 
     methods: {
+
+      setPermitsForApps(apps){
+        apps.map(app => {
+          return this.Permissions.can('update', 'App', { appName: app.name })
+            .then(res => {
+              app.display = res;
+            });
+        });   
+      },
 
       editLink(app) {
         if (app.panels && app.panels.component == 'Dashboard') {

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if="canEdit('app.name')" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">
@@ -221,7 +221,6 @@
       } else {
         this.panelTypeFilter = this.$route.params.paneltype;
       }
-      this.loadStats(this.chartType)
     },
 
     computed: {
@@ -297,7 +296,7 @@
       ...mapState({
         apps: state => state.apps,
         appsLoaded: state => state.appsLoaded,
-        permitedApps: state => state.Permissions.update
+        permitedApps: state => state.permits
       })
 
     },
@@ -309,6 +308,18 @@
           return `/apps/${app.name}?mode=edit`
         } else {
           return `/apps/${app.name}/builder2`
+        }
+      },
+
+      async canEdit(app_name) {
+        try {
+          let permissions = await this.permitedApps; // Wait for the permissions promise to resolve
+          let result = permissions.update.app_names.includes(app_name);
+          console.log(result)
+          return result
+        } catch (error) {
+            console.error("Error:", error);
+            return false; // Return false in case of any error
         }
       },
 

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink v-if="canEdit('app.name')" :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if= "validatePermission(app.name)" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">
@@ -296,7 +296,7 @@
       ...mapState({
         apps: state => state.apps,
         appsLoaded: state => state.appsLoaded,
-        permitedApps: state => state.permits
+        Permissions: state => state.Permissions
       })
 
     },
@@ -311,16 +311,9 @@
         }
       },
 
-      async canEdit(app_name) {
-        try {
-          let permissions = await this.permitedApps; // Wait for the permissions promise to resolve
-          let result = permissions.update.app_names.includes(app_name);
-          console.log(result)
-          return result
-        } catch (error) {
-            console.error("Error:", error);
-            return false; // Return false in case of any error
-        }
+      validatePermission(app_name) {
+         let result = this.Permissions.canEdit(app_name)
+         return result
       },
 
       async loadStats(type) {

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -294,10 +294,11 @@
         return `${this.titleizedAppFilter}s`
       },
 
-      ...mapState([
-        'apps',
-        'appsLoaded'
-      ])
+      ...mapState({
+        apps: state => state.apps,
+        appsLoaded: state => state.appsLoaded,
+        permitedApps: state => state.Permissions.update
+      })
 
     },
 

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink v-if= "validatePermission(app.name)" :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if= "Permissions.canEdit(app.name)" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">
@@ -309,11 +309,6 @@
         } else {
           return `/apps/${app.name}/builder2`
         }
-      },
-
-      validatePermission(app_name) {
-         let result = this.Permissions.canEdit(app_name)
-         return result
       },
 
       async loadStats(type) {

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -63,7 +63,7 @@
               <RouterLink :to="`/apps/${app.name}/`">{{panelType(app)}}</RouterLink>
             </td>
             <td>{{lastRun(app)}}</td>
-            <td><RouterLink v-if= "Permissions.canEdit(app.name)" :to="editLink(app)">Edit</RouterLink></td>
+            <td><RouterLink v-if= "Permissions.can('update', 'App', {appName:app.name})" :to="editLink(app)">Edit</RouterLink></td>
             <!-- <td><a :href="`/apps/${app.name}/builder2`">Edit</a></td> -->
             <td colspan="2">
               <RouterLink :to="`/apps/${app.name}/activity`">

--- a/src/components/AppsOverview.vue
+++ b/src/components/AppsOverview.vue
@@ -221,6 +221,7 @@
       } else {
         this.panelTypeFilter = this.$route.params.paneltype;
       }
+      this.loadStats(this.chartType)
     },
 
     computed: {

--- a/src/components/OrganizationSettings.vue
+++ b/src/components/OrganizationSettings.vue
@@ -78,13 +78,6 @@ export default {
 
   methods: {
 
-    // deletable(user) {
-    //   if (this.userRole === 'admin'){
-    //     return user.role != 'admin' || !this.lastAdmin
-    //   }
-    //   return false
-    // },
-
     async loadOrganization(){
       try{
         this.organization = await this.$store.state.Session.apiCall(`/organizations/${this.orgId}`)

--- a/src/components/OrganizationSettings.vue
+++ b/src/components/OrganizationSettings.vue
@@ -25,7 +25,7 @@
 <!--             <td>{{ user.invitation_status }}</td>
             <td>{{ user.date_added }}</td>
  -->            <td>
-              <a v-if="deletable(user)" href="#" @click="removeUser(user)"><Icon icon="trash"></Icon></a>
+              <a v-if="Permissions.can('removeMember', 'Org', {memberRole: user.role, userRole: currentUserRole, lastAdmin: lastAdmin })" href="#" @click="removeUser(user)"><Icon icon="trash"></Icon></a>
             </td>
           </tr>
         </tbody>
@@ -38,7 +38,7 @@
 <script>
 
 import Icon from './Icon.vue'
-
+import { mapState } from "vuex";
 export default {
 
   data(){
@@ -73,16 +73,17 @@ export default {
       return this.users.length === 1
     },
 
+    ...mapState(['Permissions'])
   },
 
   methods: {
 
-    deletable(user) {
-      if (this.userRole === 'admin'){
-        return user.role != 'admin' || !this.lastAdmin
-      }
-      return false
-    },
+    // deletable(user) {
+    //   if (this.userRole === 'admin'){
+    //     return user.role != 'admin' || !this.lastAdmin
+    //   }
+    //   return false
+    // },
 
     async loadOrganization(){
       try{
@@ -96,7 +97,7 @@ export default {
     },
 
     findUserRole(){
-      this.userRole = this.users.find(user => user.user_id === (this.$store.state.user.id))?.role
+      this.currentUserRole = this.users.find(user => user.user_id === (this.$store.state.user.id))?.role
     },
 
     async deleteOrganization() {

--- a/src/components/OrganizationSettings.vue
+++ b/src/components/OrganizationSettings.vue
@@ -78,17 +78,25 @@ export default {
   methods: {
 
     deletable(user) {
-      return user.role != 'admin' || !this.lastAdmin
+      if (this.userRole === 'admin'){
+        return user.role != 'admin' || !this.lastAdmin
+      }
+      return false
     },
 
     async loadOrganization(){
       try{
         this.organization = await this.$store.state.Session.apiCall(`/organizations/${this.orgId}`)
         this.users.push(...this.organization.users)
+        this.findUserRole()
       } catch(error){
         // TODO these should all print to the UI, not the console
         console.error('[OrganizationSettings][loadOrganization] Error:', error)
       }
+    },
+
+    findUserRole(){
+      this.userRole = this.users.find(user => user.user_id === (this.$store.state.user.id))?.role
     },
 
     async deleteOrganization() {

--- a/src/components/builderv2/AppTransferManager.vue
+++ b/src/components/builderv2/AppTransferManager.vue
@@ -82,6 +82,7 @@ export default {
             this.delayTransferIndicator(resolve);
           });
           this.transfer_error = true;
+          console.error(error)
         }
       }
     },

--- a/src/components/panels/Dashboard.vue
+++ b/src/components/panels/Dashboard.vue
@@ -21,13 +21,13 @@
      </div>
       <div class="panels-container">
         <div class="row" v-for="childApp in partialWidthPanels">
-          <component v-if="start_at && end_at" :is="childApp.component" :key="childApp.id" :app_id="childApp.id" :parent_app_id="app.name" :options="{start_at: start_at, end_at: end_at}" @set-selected-panel-values="setSelectedPanelValues"/>
+          <component v-if="start_at && end_at" :is="childApp.component" :key="childApp.id" :app_id="childApp.id" :parent_app_id="app.name" :can_update = "childApp.canUpdate" :options="{start_at: start_at, end_at: end_at}" @set-selected-panel-values="setSelectedPanelValues"/>
         </div>
       </div>
 
       <div class="full-width-panels-container">
         <div v-for="childApp in fullWidthPanels" class="full-width-panel-container">
-          <component v-if="start_at && end_at" :is="childApp.component" :key="childApp.id" :app_id="childApp.id" :parent_app_id="app.name" :options="{start_at: start_at, end_at: end_at}" @set-selected-panel-values="setSelectedPanelValues"/>
+          <component v-if="start_at && end_at" :is="childApp.component" :key="childApp.id" :app_id="childApp.id" :parent_app_id="app.name" :can_update = "childApp.canUpdate" :options="{start_at: start_at, end_at: end_at}" @set-selected-panel-values="setSelectedPanelValues"/>
         </div>
       </div>
  
@@ -104,7 +104,8 @@
           .map(app => {return {
             id: app.name,
             component: app.panels.component,
-            options: app.panels.options
+            options: app.panels.options,
+            canUpdate: app.canUpdate
             }
           })
           .filter(panel => this.panelIds.includes(panel.id))

--- a/src/components/panels/Headline.vue
+++ b/src/components/panels/Headline.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel" :class="{standalone: standAlone}">
     <div class="panel-inner">
-      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" />
+      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" :can_update = "can_update" />
       <h2 v-if="cascadingTitle">{{cascadingTitle}}</h2>
       <p v-if="cascadingDescription">{{cascadingDescription}}</p>
       <h1>

--- a/src/components/panels/HeadlineTable.vue
+++ b/src/components/panels/HeadlineTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel" :class="{standalone: standAlone}">
     <div class="panel-inner">
-      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" />
+      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" :can_update = "can_update"/>
       <h2 v-if="cascadingTitle">{{cascadingTitle}}</h2>
       <p v-if="cascadingDescription">{{cascadingDescription}}</p>
 

--- a/src/components/panels/LineChart.vue
+++ b/src/components/panels/LineChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel">
     <div :class="size">
-      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" />
+      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" :can_update = "can_update"/>
       <h2 v-if="cascadingTitle">{{cascadingTitle}}</h2>
       <p v-if="cascadingDescription">{{cascadingDescription}}</p>
       <div ref="series-1" class="pallet series-1"></div>

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -68,7 +68,7 @@
 
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit' 
+        return p.get('mode') == 'edit' && this.Permissions.canEdit(this.app_id)
       },
 
       editUrl() {
@@ -145,7 +145,7 @@
       },
 
       ...mapState([
-        'apps', 'user'])
+        'apps', 'user', 'Permissions'])
 
     },
 

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -33,7 +33,7 @@
     },
 
     data() {
-      return this.intialData()
+      return this.initialData()
     },
 
     watch: {
@@ -68,7 +68,11 @@
 
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit' && this.Permissions.can('update', 'App', {appName: this.app_id})
+        this.Permissions.can('update', 'App', {appName: this.app_id})
+        .then((res) => {
+          this.canEdit = res
+        })
+        return p.get('mode') == 'edit' && this.canEdit
       },
 
       editUrl() {
@@ -168,7 +172,7 @@
         return out
       },
 
-      intialData() {
+      initialData() {
         return {
           chartOptions: {},
           errors: '',
@@ -183,11 +187,12 @@
           rows: [],
           columnNames: [],
           headlines: [{count: '-', title: 'Loading...'}],
+          canEdit: false
         }
       },
 
       resetState() {
-        Object.assign(this.$data, this.intialData())
+        Object.assign(this.$data, this.initialData())
       },
 
       async fetchData() {

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -17,7 +17,7 @@
         type: String,
         required: false
       },
-      
+
       can_update: {
         type: Boolean, 
         required: false
@@ -72,13 +72,9 @@
         return this.app_id == url_app_id
       },
 
-      editMode() {
+      editMode(can_update) {
         let p = new URLSearchParams(window.location.search)
-        this.Permissions.can('update', 'App', {appName: this.app_id})
-        .then((res) => {
-          this.canEdit = res
-        })
-        return p.get('mode') == 'edit' && this.canEdit
+        return p.get('mode') == 'edit' && this.app.canUpdate
       },
 
       editUrl() {
@@ -155,7 +151,7 @@
       },
 
       ...mapState([
-        'apps', 'user', 'Permissions'])
+        'apps', 'user', 'Permissions', 'app'])
 
     },
 
@@ -193,7 +189,7 @@
           rows: [],
           columnNames: [],
           headlines: [{count: '-', title: 'Loading...'}],
-          canEdit: false
+          canUpdate: false
         }
       },
 

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -72,7 +72,7 @@
         return this.app_id == url_app_id
       },
 
-      editMode(can_update) {
+      editMode() {
         let p = new URLSearchParams(window.location.search)
         return p.get('mode') == 'edit' && this.app.canUpdate
       },

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -17,6 +17,12 @@
         type: String,
         required: false
       },
+      
+      can_update: {
+        type: Boolean, 
+        required: false
+      },
+
       options: {
         type: Object,
         required: false

--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -68,7 +68,7 @@
 
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit' && this.Permissions.canEdit(this.app_id)
+        return p.get('mode') == 'edit' && this.Permissions.can('update', 'App', {appName: this.app_id})
       },
 
       editUrl() {

--- a/src/components/panels/PanelPopover.vue
+++ b/src/components/panels/PanelPopover.vue
@@ -28,6 +28,11 @@
       app_id: {
         type: String,
         required: true
+      },
+
+      can_update: {
+        type: Boolean,
+        required: true
       }
     },
 
@@ -44,11 +49,7 @@
     computed: {
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        this.Permissions.can('update', 'App', {appName: this.app_id})
-        .then((res) => {
-          this.canEdit = res
-        })
-        return p.get('mode') == 'edit' && this.canEdit
+        return p.get('mode') == 'edit' && this.can_update
       },
       ...mapState({
         Permissions: state => state.Permissions

--- a/src/components/panels/PanelPopover.vue
+++ b/src/components/panels/PanelPopover.vue
@@ -14,6 +14,7 @@
 
   import App from '../../models/App'
   import Icon from '../Icon.vue'
+  import { mapState } from "vuex";
 
   export default {
 
@@ -37,8 +38,11 @@
     computed: {
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit'
+        return p.get('mode') == 'edit' && this.Permissions.canEdit(this.app_id)
       },
+      ...mapState({
+        Permissions: state => state.Permissions
+      })
     },
 
     methods: {

--- a/src/components/panels/PanelPopover.vue
+++ b/src/components/panels/PanelPopover.vue
@@ -38,7 +38,7 @@
     computed: {
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit' && this.Permissions.canEdit(this.app_id)
+        return p.get('mode') == 'edit' && this.Permissions.can('update', 'App', {appName: this.app_id})
       },
       ...mapState({
         Permissions: state => state.Permissions

--- a/src/components/panels/PanelPopover.vue
+++ b/src/components/panels/PanelPopover.vue
@@ -40,12 +40,6 @@
       Icon
     },
 
-    data(){
-      return {
-        canEdit: false
-      }
-    },
-
     computed: {
       editMode() {
         let p = new URLSearchParams(window.location.search)

--- a/src/components/panels/PanelPopover.vue
+++ b/src/components/panels/PanelPopover.vue
@@ -35,10 +35,20 @@
       Icon
     },
 
+    data(){
+      return {
+        canEdit: false
+      }
+    },
+
     computed: {
       editMode() {
         let p = new URLSearchParams(window.location.search)
-        return p.get('mode') == 'edit' && this.Permissions.can('update', 'App', {appName: this.app_id})
+        this.Permissions.can('update', 'App', {appName: this.app_id})
+        .then((res) => {
+          this.canEdit = res
+        })
+        return p.get('mode') == 'edit' && this.canEdit
       },
       ...mapState({
         Permissions: state => state.Permissions

--- a/src/components/panels/StackedBarChart.vue
+++ b/src/components/panels/StackedBarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel" >
     <div :class="size">
-      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" />
+      <PanelPopover :app_id="app_id" :parent_app_id="parent_app_id" :can_update = "can_update"/>
       <h2 v-if="cascadingTitle">{{cascadingTitle}}</h2>
       <p v-if="cascadingDescription">{{cascadingDescription}}</p>
       <div ref="series-1" class="pallet series-1"></div>

--- a/src/models/App.js
+++ b/src/models/App.js
@@ -36,6 +36,7 @@ export default class App {
     await this.instantiateManifest(appInstance)
     Object.assign(this, appInstance)
     await this.$store.state.Permissions.reload()
+    this.$store.dispatch("setAppPermits")
     return appInstance
   }
 
@@ -62,6 +63,7 @@ export default class App {
     this.$store.state.Session.apiCall(`/apps/${this.name}`, 'DELETE')
     this.$store.commit('removeApp', {name: this.name})
     await this.$store.state.Permissions.reload()
+    this.$store.dispatch("setAppPermits")
   }
 
   async removeCredentials() {

--- a/src/models/App.js
+++ b/src/models/App.js
@@ -35,7 +35,7 @@ export default class App {
     this.$store.commit('addApp', appInstance)
     await this.instantiateManifest(appInstance)
     Object.assign(this, appInstance)
-    await this.$store.dispatch('loadPermissions')
+    await this.$store.state.Permissions.load()
     return appInstance
   }
 
@@ -61,7 +61,7 @@ export default class App {
     }
     this.$store.state.Session.apiCall(`/apps/${this.name}`, 'DELETE')
     this.$store.commit('removeApp', {name: this.name})
-    await this.$store.dispatch('loadPermissions')
+    await this.$store.state.Permissions.load()
   }
 
   async removeCredentials() {

--- a/src/models/App.js
+++ b/src/models/App.js
@@ -35,8 +35,8 @@ export default class App {
     this.$store.commit('addApp', appInstance)
     await this.instantiateManifest(appInstance)
     Object.assign(this, appInstance)
-    await this.$store.state.Permissions.reload()
-    this.$store.dispatch("setAppPermits")
+    await this.$store.state.Permissions.reset()
+    this.$store.dispatch("setAppPermits", this.$store.state.apps)
     return appInstance
   }
 
@@ -62,8 +62,8 @@ export default class App {
     }
     this.$store.state.Session.apiCall(`/apps/${this.name}`, 'DELETE')
     this.$store.commit('removeApp', {name: this.name})
-    await this.$store.state.Permissions.reload()
-    this.$store.dispatch("setAppPermits")
+    await this.$store.state.Permissions.reset()
+    this.$store.dispatch("setAppPermits", this.$store.state.apps)
   }
 
   async removeCredentials() {

--- a/src/models/App.js
+++ b/src/models/App.js
@@ -35,7 +35,7 @@ export default class App {
     this.$store.commit('addApp', appInstance)
     await this.instantiateManifest(appInstance)
     Object.assign(this, appInstance)
-    await this.$store.state.Permissions.load()
+    await this.$store.state.Permissions.reload()
     return appInstance
   }
 
@@ -61,7 +61,7 @@ export default class App {
     }
     this.$store.state.Session.apiCall(`/apps/${this.name}`, 'DELETE')
     this.$store.commit('removeApp', {name: this.name})
-    await this.$store.state.Permissions.load()
+    await this.$store.state.Permissions.reload()
   }
 
   async removeCredentials() {

--- a/src/models/App.js
+++ b/src/models/App.js
@@ -35,6 +35,7 @@ export default class App {
     this.$store.commit('addApp', appInstance)
     await this.instantiateManifest(appInstance)
     Object.assign(this, appInstance)
+    await this.$store.dispatch('loadPermissions')
     return appInstance
   }
 
@@ -60,6 +61,7 @@ export default class App {
     }
     this.$store.state.Session.apiCall(`/apps/${this.name}`, 'DELETE')
     this.$store.commit('removeApp', {name: this.name})
+    await this.$store.dispatch('loadPermissions')
   }
 
   async removeCredentials() {

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -6,21 +6,25 @@ export default class Permissions {
     this.userId = userId;
     this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
   }
-  canEdit(appName) {
-    if (!this.permissions) {
-      return false;
-    } else {
-      try {
-        let updateAppNames = this.permissions.update.app_names;
-        if (updateAppNames.includes(appName)) {
-          return true;
+
+  can(ability, model, {appName: appName}) {
+    if(this.permissions){
+      if(model === 'App'){
+        let abilities = ['destroy', 'update', 'grant', 'transfer']
+        if (abilities.includes(ability)){
+          try {
+            let appNames = this.permissions[ability].app_names;
+            return appNames.includes(appName)
+          } catch (error) {
+            console.error("Error:", error);
+            return false;
+          }
         } else {
-          return false;
+          console.err(`Ability: ${ability} not found in App permissions`)
+          return false
         }
-      } catch (error) {
-        console.error("Error:", error);
-        return false;
       }
     }
+    return false
   }
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -25,7 +25,7 @@ export default class Permissions {
 
   constructor(Session, user) {
     this.Session = Session
-    this._userId = user.id
+    this._userId = user?.id
     if (!this._userId || !this.Session) {
       throw new Error("User and Session is required.");
     }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -63,11 +63,11 @@ export default class Permissions {
         let appNames = permissions[ability]?.app_names;
         return appNames.includes(appName);
       } else {
-        throw new Error(`Ability - ${ability} not found in App permissions`);
+        console.error(`Ability: ${ability} not found in App permissions`);
         return false;
       }
     } catch (error) {
-      console.error("Error:", error);
+      console.error(error);
       return false;
     }
   }
@@ -83,11 +83,11 @@ export default class Permissions {
         }
         return false;
       } else {
-        throw new Error(`Ability - ${ability} not found in Org permissions`);
+        console.error(`Ability: ${ability} not found in Org permissions`);
         return false;
       }
     } catch (error) {
-      console.error("Error:", error);
+      console.error(error);
       return false;
     }
   }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,0 +1,6 @@
+export default class Permissions {
+    constructor() {}
+    static setPermissions(permissions){
+        this.update = permissions.update
+    }
+}

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,9 +1,11 @@
 import Session from './Session'
 export default class Permissions {
-    constructor() {
-        const userPermissions = await Session.apiCall(`/users/${state.user.id}/permissions`)
+
+    constructor(){}
+
+    static async setUserPermits(user_id){
+        let userPermissions = await Session.apiCall(`/users/${user_id}/permissions`)
+        return userPermissions
     }
-    static setPermissions(permissions){
-        this.update = permissions.update
-    }
+
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -2,7 +2,7 @@ import Session from "./Session";
 export default class Permissions {
   constructor() {}
 
-  async setUserPermits(userId) {
+  async loadPermissions(userId) {
     this.userId = userId;
     this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
   }
@@ -23,6 +23,8 @@ export default class Permissions {
           console.err(`Ability: ${ability} not found in App permissions`)
           return false
         }
+      } else {
+        console.error(`Model: ${model} not found`)
       }
     }
     return false

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -2,58 +2,71 @@ import Session from "./Session";
 export default class Permissions {
   constructor() {}
 
-  async loadPermissions(userId) {
-    this.userId = userId;
-    this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
+  async load(userId) {
+    try {
+      this._userId = userId || this._userId;
+      if (!this._userId) {
+        throw new Error("User ID is required.");
+      }
+      this._permissions = await Session.apiCall(`/users/${this._userId}/permissions`);
+    } catch (error) {
+      console.error("Error loading permissions:", error.message);
+    }
   }
 
   can(ability, model, args) {
-    const validateAppAbility = (ability, { appName: appName }) => {
-      try {
-        let abilities = ["destroy", "update", "grant", "transfer"];
-        if (abilities.includes(ability)) {
-          let appNames = this.permissions[ability]?.app_names;
-          return appNames.includes(appName);
-        } else {
-          throw new Error(`Ability: ${ability} not found in App permissions`);
-          return false;
-        }
-      } catch (error) {
-        console.error("Error:", error);
-        return false;
-      }
-    };
+    return this.validate(this._permissions, ability, model, args)
+  }
 
-    const validateOrgAbility = (
-      ability,
-      { memberRole: memberRole, userRole: userRole, lastAdmin: isLastAdmin }
-    ) => {
-      try {
-        if (ability === "removeMember") {
-          if (userRole === "admin") {
-            return memberRole !== "admin" || !lastAdmin;
-          }
-          return false;
-        } else {
-          throw new Error(`Ability - ${ability} not found in Org permissions`);
-          return false;
-        }
-      } catch (error) {
-        console.error("Error:", error);
-        return false;
-      }
-    };
-
-    if (this.permissions) {
-      if (model === "App") {
-        return validateAppAbility(ability, args);
-      } else if (model === "Org") {
-        return validateOrgAbility(ability, args);
-      } else {
-        console.error(`Model: ${model} not found`);
-        return false;
-      }
+  validate(permissions, ability, model, args) {
+    if (!permissions) {
+      console.error("Permissions have not been initialized.")
+      return false
     }
-    return false;
+    if (model === "App") {
+      return this.validateAppAbility(permissions, ability, args);
+    } else if (model === "Org") {
+      return this.validateOrgAbility(permissions, ability, args);
+    } else {
+      console.error(`Model: ${model} not found`);
+      return false;
+    }
+  }
+
+  validateAppAbility(permissions, ability, { appName: appName }) {
+    try {
+      let abilities = ["destroy", "update", "grant", "transfer"];
+      if (abilities.includes(ability)) {
+        let appNames = this._permissions[ability]?.app_names;
+        return appNames.includes(appName);
+      } else {
+        throw new Error(`Ability - ${ability} not found in App permissions`);
+        return false;
+      }
+    } catch (error) {
+      console.error("Error:", error);
+      return false;
+    }
+  }
+
+  validateOrgAbility(
+    permissions,
+    ability,
+    { memberRole: memberRole, userRole: userRole, lastAdmin: isLastAdmin }
+  ) {
+    try {
+      if (ability === "removeMember") {
+        if (userRole === "admin") {
+          return memberRole !== "admin" || !lastAdmin;
+        }
+        return false;
+      } else {
+        throw new Error(`Ability - ${ability} not found in Org permissions`);
+        return false;
+      }
+    } catch (error) {
+      console.error("Error:", error);
+      return false;
+    }
   }
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,4 +1,3 @@
-import Session from "./Session";
 export default class Permissions {
 
   // Creating a Permissions instance:
@@ -24,7 +23,9 @@ export default class Permissions {
   // validateAppAbility() and validateOrgAbility() are called in can(). It's recommended to use can() to ensure
   // that you are committing an ability towards an available/appropriate model
 
-  constructor() {}
+  constructor(Session) {
+    this.Session = Session
+  }
 
   async load(userId) {
     try {
@@ -32,7 +33,7 @@ export default class Permissions {
       if (!this._userId) {
         throw new Error("User ID is required.");
       }
-      this._permissions = await Session.apiCall(
+      this._permissions = await this.Session.apiCall(
         `/users/${this._userId}/permissions`
       );
     } catch (error) {

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,86 +1,78 @@
 export default class Permissions {
+// Creating a Permissions instance:
+// const permissions = new Permissions()
 
-  // Creating a Permissions instance:
-  // const permissions = new Permissions()
+// Method: can()
+// Description:
+// Validates whether the user can perform specific actions on apps or organizations.
+// It loads permissions if they are not set and checks the provided ability, model, and args.
+// Args required are specified in validateOrgAbility() and validateAppAbility().
+// Returns:
+// A boolean indicating whether the user can perform the specified action.
+// Example usage:
+// - permissions.can('update', 'App', {appName: appName})
+// - permissions.can('removeUser', 'Org', {memberRole: memberRole, userRole: userRole, lastAdmin: lastAdmin})
 
-  // Method: load()
-  // Description:
-  // Load the user's permissions list by making an API call. The user's ID is required for the first call,
-  // and reused for subsequent calls unless a new one is specified.
-  // Returns: A promise that resolves with the user's permissions list.
-  // Example usage: permissions.load(userId) or permissions.load()
+// Note on validateAppAbility() and validateOrgAbility():
+// These methods are called in validate(), which is then invoked in can().
+// It's recommended to use can() to ensure the ability is assigned to an available/appropriate model.
 
-  // Method: can()
-  // Description:
-  // Validate app actions by checking ability, model, and args. Returns a boolean to verify that the user
-  // can perform the specified action. Args required are specified in validateOrgAbility() and validateAppAbility().
-  // Returns: A boolean indicating whether the user can perform the specified action.
-  // Example usage:
-  // - permissions.can('update', 'App', {appName: appName})
-  // - permissions.can('removeUser', 'Org', {memberRole: memberRole, userRole: userRole, lastAdmin: lasAdmin})
-
-  // Note:
-  // validateAppAbility() and validateOrgAbility() are called in can(). It's recommended to use can() to ensure
-  // that you are committing an ability towards an available/appropriate model
+// Note on removeMember ability: 
+// In the current implementation, an admin cannot remove themselves from the organization
+// if they are the last admin in the group.
 
   constructor(Session, user) {
-    this.Session = Session
-    this._userId = user?.id
+    this.Session = Session;
+    this._userId = user?.id;
     if (!this._userId || !this.Session) {
       throw new Error("User and Session is required.");
     }
   }
 
   load() {
-    this._permissions = this._permissions || this.Session.apiCall(
-      `/users/${this._userId}/permissions`
-    );
-    return this._permissions
+    this._permissions =
+      this._permissions ||
+      this.Session.apiCall(`/users/${this._userId}/permissions`);
+    return this._permissions;
   }
 
-  reset(){
-    this._permissions = null
+  reset() {
+    this._permissions = null;
   }
 
   can(ability, model, args) {
-    return this.load().then((permissions) => {
-      return this.validate(permissions, ability, model, args)
-    })
-    .catch((error) => {
-      return false
-      console.error(error)
-    })
+    return this.load()
+      .then((permissions) => {
+        return this.validate(permissions, ability, model, args);
+      })
+      .catch((error) => {
+        console.error(error);
+        return false;
+      });
   }
 
-  validate(permissions, ability, model, args){
-    if (!permissions) {
-      console.error("Permissions have not been initialized.");
-      return false;
-    }
+  validate(permissions, ability, model, args) {
     if (model === "App") {
       return this.validateAppAbility(permissions, ability, args);
     } else if (model === "Org") {
       return this.validateOrgAbility(ability, args);
     } else {
-      console.error(`Model: ${model} not found`);
-      return false;
+      throw new Error(`Model: ${model} not found`);
     }
   }
 
-  validateAppAbility(permissions, ability, { appName: appName}) {
-    try {
-      let abilities = ['destroy', 'update', 'grant', 'transfer'];
-      if (abilities.includes(ability)) {
+  validateAppAbility(permissions, ability, { appName: appName }) {
+    let abilities = ["destroy", "update", "grant", "transfer"];
+    if (abilities.includes(ability)) {
+      if (!appName) {
+        throw new Error("appName is required in args");
+      } else {
         let appNames = permissions[ability]?.app_names;
         let response = appNames.includes(appName);
-        return response
-      } else {
-        console.error(`Ability: ${ability} not found in App permissions`);
-        return false;
+        return response;
       }
-    } catch (error) {
-      console.error(error);
-      return false;
+    } else {
+      throw new Error(`Ability: ${ability} not found in App permissions`);
     }
   }
 
@@ -88,19 +80,23 @@ export default class Permissions {
     ability,
     { memberRole: memberRole, userRole: userRole, lastAdmin: lastAdmin }
   ) {
-    try {
-      if (ability === "removeMember") {
+    if (ability === "removeMember") {
+      if (!memberRole || !userRole || lastAdmin === undefined) {
+        throw new Error(
+          "memberRole, userRole, and lastAdmin are required in args"
+        );
+      } else {
         if (userRole === "admin") {
-          return memberRole !== "admin" || !lastAdmin;
+          if (memberRole === "member") {
+            return true;
+          } else {
+            return memberRole === "admin" && !lastAdmin;
+          }
         }
         return false;
-      } else {
-        console.error(`Ability: ${ability} not found in Org permissions`);
-        return false;
       }
-    } catch (error) {
-      console.error(error);
-      return false;
+    } else {
+      throw new Error(`Ability: ${ability} not found in Org permissions`);
     }
   }
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -38,10 +38,8 @@ export default class Permissions {
     return this._permissions
   }
 
-  reload(){
-    this._permissions = this.Session.apiCall(
-        `/users/${this._userId}/permissions`
-      );
+  reset(){
+    this._permissions = null
   }
 
   can(ability, model, args) {

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -7,53 +7,53 @@ export default class Permissions {
     this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
   }
 
-
   can(ability, model, args) {
-    const validateAppAbility  = (ability, {appName: appName}) => {
-      let abilities = ['destroy', 'update', 'grant', 'transfer']
-      if (abilities.includes(ability)){
-        try {
+    const validateAppAbility = (ability, { appName: appName }) => {
+      try {
+        let abilities = ["destroy", "update", "grant", "transfer"];
+        if (abilities.includes(ability)) {
           let appNames = this.permissions[ability]?.app_names;
-          return appNames.includes(appName)
-        } catch (error) {
-          console.error("Error:", error);
+          return appNames.includes(appName);
+        } else {
+          throw new Error(`Ability: ${ability} not found in App permissions`);
           return false;
         }
-      } else {
-        console.err(`Ability: ${ability} not found in App permissions`)
-        return false
+      } catch (error) {
+        console.error("Error:", error);
+        return false;
       }
-    }
-  
-    const validateOrgAbility = (ability, {memberRole: memberRole, userRole: userRole, lastAdmin: isLastAdmin}) => {
-      if (ability === 'removeMember'){
-        try{
-          if (userRole === 'admin'){
-            return memberRole != 'admin' || !isLastAdmin
+    };
+
+    const validateOrgAbility = (
+      ability,
+      { memberRole: memberRole, userRole: userRole, lastAdmin: isLastAdmin }
+    ) => {
+      try {
+        if (ability === "removeMember") {
+          if (userRole === "admin") {
+            return memberRole !== "admin" || !lastAdmin;
           }
-          return false
-        } catch (error) {
-          console.error("Error: ", error)
-          return false
+          return false;
+        } else {
+          throw new Error(`Ability - ${ability} not found in Org permissions`);
+          return false;
         }
+      } catch (error) {
+        console.error("Error:", error);
+        return false;
+      }
+    };
+
+    if (this.permissions) {
+      if (model === "App") {
+        return validateAppAbility(ability, args);
+      } else if (model === "Org") {
+        return validateOrgAbility(ability, args);
       } else {
-        console.err(`Ability: ${ability} not found in Org permissions`)
-        return false
+        console.error(`Model: ${model} not found`);
+        return false;
       }
     }
-
-    if(this.permissions){
-      if(model === 'App'){
-        return validateAppAbility(ability, args)
-      } else if(model === 'Org'){
-        return validateOrgAbility(ability, args)
-      } else {
-        console.error(`Model: ${model} not found`)
-        return false
-      }
-    }
-    return false
-
+    return false;
   }
-
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,5 +1,8 @@
+import Session from './Session'
 export default class Permissions {
-    constructor() {}
+    constructor() {
+        const userPermissions = await Session.apiCall(`/users/${state.user.id}/permissions`)
+    }
     static setPermissions(permissions){
         this.update = permissions.update
     }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -1,11 +1,26 @@
-import Session from './Session'
+import Session from "./Session";
 export default class Permissions {
+  constructor() {}
 
-    constructor(){}
-
-    static async setUserPermits(user_id){
-        let userPermissions = await Session.apiCall(`/users/${user_id}/permissions`)
-        return userPermissions
+  async setUserPermits(userId) {
+    this.userId = userId;
+    this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
+  }
+  canEdit(appName) {
+    if (!this.permissions) {
+      return false;
+    } else {
+      try {
+        let updateAppNames = this.permissions.update.app_names;
+        if (updateAppNames.includes(appName)) {
+          return true;
+        } else {
+          return false;
+        }
+      } catch (error) {
+        console.error("Error:", error);
+        return false;
+      }
     }
-
+  }
 }

--- a/src/models/Permissions.js
+++ b/src/models/Permissions.js
@@ -7,26 +7,53 @@ export default class Permissions {
     this.permissions = await Session.apiCall(`/users/${userId}/permissions`);
   }
 
-  can(ability, model, {appName: appName}) {
-    if(this.permissions){
-      if(model === 'App'){
-        let abilities = ['destroy', 'update', 'grant', 'transfer']
-        if (abilities.includes(ability)){
-          try {
-            let appNames = this.permissions[ability].app_names;
-            return appNames.includes(appName)
-          } catch (error) {
-            console.error("Error:", error);
-            return false;
+
+  can(ability, model, args) {
+    const validateAppAbility  = (ability, {appName: appName}) => {
+      let abilities = ['destroy', 'update', 'grant', 'transfer']
+      if (abilities.includes(ability)){
+        try {
+          let appNames = this.permissions[ability]?.app_names;
+          return appNames.includes(appName)
+        } catch (error) {
+          console.error("Error:", error);
+          return false;
+        }
+      } else {
+        console.err(`Ability: ${ability} not found in App permissions`)
+        return false
+      }
+    }
+  
+    const validateOrgAbility = (ability, {memberRole: memberRole, userRole: userRole, lastAdmin: isLastAdmin}) => {
+      if (ability === 'removeMember'){
+        try{
+          if (userRole === 'admin'){
+            return memberRole != 'admin' || !isLastAdmin
           }
-        } else {
-          console.err(`Ability: ${ability} not found in App permissions`)
+          return false
+        } catch (error) {
+          console.error("Error: ", error)
           return false
         }
       } else {
+        console.err(`Ability: ${ability} not found in Org permissions`)
+        return false
+      }
+    }
+
+    if(this.permissions){
+      if(model === 'App'){
+        return validateAppAbility(ability, args)
+      } else if(model === 'Org'){
+        return validateOrgAbility(ability, args)
+      } else {
         console.error(`Model: ${model} not found`)
+        return false
       }
     }
     return false
+
   }
+
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ import FeatureManager from 'trivial-core/lib/FeatureManager'
 import ActionPath from 'trivial-core/lib/actionsv2/ActionPath'
 import router from '../router'
 import Session from '../models/Session'
+import Permissions from '../models/Permissions'
 
 const store = createStore({
 
@@ -42,6 +43,7 @@ const store = createStore({
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
+    Permissions: Permissions
   },
 
   getters: {
@@ -275,6 +277,7 @@ const store = createStore({
       if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
         await dispatch('loadApp', { appId: router.currentRoute.value.params.id })
       }
+      dispatch('loadPermissions')
     },
 
     async loadApps({ commit }) {
@@ -285,6 +288,11 @@ const store = createStore({
     async loadApp({ commit }, { appId }) {
       const app = await Session.apiCall(`/apps/${appId}`)
       await commit('setApp', app)
+    },
+
+    async loadPermissions({state, commit}) {
+      const userPermissions = await Session.apiCall(`/users/${state.user.id}/permissions`)
+      Permissions.setPermissions(userPermissions)
     },
 
     initApp({state, commit}, {appId}) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,8 +43,7 @@ const store = createStore({
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
-    Permissions: Permissions,
-    permits: null
+    Permissions: new Permissions(),
   },
 
   getters: {
@@ -292,8 +291,7 @@ const store = createStore({
     },
 
     async loadPermissions({state, commit}) {
-      state.permits = Permissions.setUserPermits(state.user.id)
-      console.log(state.permits)
+      state.permits = state.Permissions.setUserPermits(state.user.id)
     },
 
     initApp({state, commit}, {appId}) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,7 +43,7 @@ const store = createStore({
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
-    Permissions: new Permissions(Session),
+    Permissions: null
   },
 
   getters: {
@@ -208,6 +208,10 @@ const store = createStore({
       state.dataSample = dataSample
     },
 
+    initPermissions(state, user){
+      state.Permissions = new Permissions(Session, user)
+    },
+
     addListener(state, {event, listener}) {
       if (! (event in state.listeners)) {
         state.listeners[event] = []
@@ -262,7 +266,7 @@ const store = createStore({
         let data = await Session.apiCall('/profile')
         commit('setTheme', data.user.color_theme)
         commit('setUser', data.user)
-        state.Permissions.load(state.user.id)
+        commit('initPermissions', data.user)
       } catch (e) {
         console.error('Failed to load profile', e)
         commit('setUser', {name: 'guest'})

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -276,7 +276,7 @@ const store = createStore({
     async loadResources({ commit }, { dispatch, router }) {
       const routeName = router.currentRoute.value.name
       if ( ['PanelType', 'Show App'].includes(routeName) ) {
-        await dispatch('loadApps')
+        await dispatch('loadApps', {dispatch})
       }
 
       if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
@@ -284,9 +284,19 @@ const store = createStore({
       }
     },
 
-    async loadApps({ commit }) {
+    async loadApps({ commit }, {dispatch}) {
       const apps = await Session.apiCall('/apps')
       await commit('setApps', apps)
+      await dispatch('setAppPermits')
+    },
+    
+    async setAppPermits({state}){
+      state.apps.map(app => {
+        return state.Permissions.can('update', 'App', { appName: app.name })
+          .then(res => {
+            app.canUpdate = res;
+          });
+      });
     },
 
     async loadApp({ commit }, { appId }) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,7 +43,8 @@ const store = createStore({
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
-    Permissions: Permissions
+    Permissions: Permissions,
+    permits: null
   },
 
   getters: {
@@ -277,7 +278,7 @@ const store = createStore({
       if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
         await dispatch('loadApp', { appId: router.currentRoute.value.params.id })
       }
-      dispatch('loadPermissions')
+      await dispatch('loadPermissions')
     },
 
     async loadApps({ commit }) {
@@ -291,8 +292,8 @@ const store = createStore({
     },
 
     async loadPermissions({state, commit}) {
-      const userPermissions = await Session.apiCall(`/users/${state.user.id}/permissions`)
-      Permissions.setPermissions(userPermissions)
+      state.permits = Permissions.setUserPermits(state.user.id)
+      console.log(state.permits)
     },
 
     initApp({state, commit}, {appId}) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,7 +43,7 @@ const store = createStore({
     enableBuildApps: import.meta.env.VITE_ENABLE_BUILD_APPS,
     enableWebhookAppTrigger: import.meta.env.VITE_ENABLE_WEBHOOK_APP_TRIGGER,
     Session: Session,
-    Permissions: new Permissions(),
+    Permissions: new Permissions(Session),
   },
 
   getters: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -291,7 +291,7 @@ const store = createStore({
     },
 
     async loadPermissions({state, commit}) {
-      state.permits = state.Permissions.setUserPermits(state.user.id)
+      state.permits = state.Permissions.loadPermissions(state.user.id)
     },
 
     initApp({state, commit}, {appId}) {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -280,30 +280,31 @@ const store = createStore({
       }
 
       if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
-        await dispatch('loadApp', { appId: router.currentRoute.value.params.id })
+        await dispatch('loadApp', { dispatch, appId: router.currentRoute.value.params.id })
       }
     },
 
-    async loadApps({ commit }, {dispatch}) {
+    async loadApps({ commit, state }, {dispatch}) {
       const apps = await Session.apiCall('/apps')
       await commit('setApps', apps)
-      await dispatch('setAppPermits')
+      await dispatch('setAppPermits', state.apps)
     },
-    
-    async setAppPermits({state}){
-      state.apps.map(app => {
+
+    async loadApp({ commit, state }, { dispatch, appId }) {
+      const app = await Session.apiCall(`/apps/${appId}`)
+      await commit('setApp', app)
+      await dispatch('setAppPermits', [state.app])
+    },
+
+    async setAppPermits({state}, apps){
+      apps.map(app => {
         return state.Permissions.can('update', 'App', { appName: app.name })
           .then(res => {
             app.canUpdate = res;
           });
       });
     },
-
-    async loadApp({ commit }, { appId }) {
-      const app = await Session.apiCall(`/apps/${appId}`)
-      await commit('setApp', app)
-    },
-
+    
     initApp({state, commit}, {appId}) {
       if(state.app !== {}){
         state.app = {}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -262,6 +262,7 @@ const store = createStore({
         let data = await Session.apiCall('/profile')
         commit('setTheme', data.user.color_theme)
         commit('setUser', data.user)
+        state.Permissions.load(state.user.id)
       } catch (e) {
         console.error('Failed to load profile', e)
         commit('setUser', {name: 'guest'})
@@ -277,7 +278,6 @@ const store = createStore({
       if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
         await dispatch('loadApp', { appId: router.currentRoute.value.params.id })
       }
-      await dispatch('loadPermissions')
     },
 
     async loadApps({ commit }) {
@@ -288,10 +288,6 @@ const store = createStore({
     async loadApp({ commit }, { appId }) {
       const app = await Session.apiCall(`/apps/${appId}`)
       await commit('setApp', app)
-    },
-
-    async loadPermissions({state, commit}) {
-      state.permits = state.Permissions.loadPermissions(state.user.id)
     },
 
     initApp({state, commit}, {appId}) {

--- a/test/lib/Permissions.js
+++ b/test/lib/Permissions.js
@@ -169,7 +169,7 @@ describe("Permissions", () => {
     it("should throw an error if appropriate args are not set for validating org abilities", () => {
       try {
         permissions.validateOrgAbility("removeMember", {memberRole: undefined, userRole: undefined, lastAdmin: undefined});
-        expectt.fail("Validation for args fail did not pass");
+        expectt.fail("Validation for org args fail did not pass");
       } catch (error) {
         expect(error.message).to.equal("memberRole, userRole, and lastAdmin are required in args");
       }
@@ -177,7 +177,7 @@ describe("Permissions", () => {
     it("should throw an error if appropriate args are not set for validating app abilities", () => {
       try {
         permissions.validateAppAbility(mockPermissionsResponse, "update", {appName: undefined});
-        expectt.fail("Validation for args fail did not pass");
+        expectt.fail("Validation for app args fail did not pass");
       } catch (error) {
         expect(error.message).to.equal("appName is required in args");
       }

--- a/test/lib/Permissions.js
+++ b/test/lib/Permissions.js
@@ -12,6 +12,7 @@ let mockPermissionsResponse = {
       "0b07af48aa8991",
       "5fbd0cef5d9306",
       "c4c270d211fea2",
+      "5b83e11ab9ff8e"
     ],
     credential_set_ids: [],
   },
@@ -21,6 +22,7 @@ let mockPermissionsResponse = {
       "0b07af48aa8991",
       "5fbd0cef5d9306",
       "c4c270d211fea2",
+      "a2dcf60ef9a7c3"
     ],
     credential_set_ids: [],
   },
@@ -30,6 +32,7 @@ let mockPermissionsResponse = {
       "0b07af48aa8991",
       "5fbd0cef5d9306",
       "c4c270d211fea2",
+      "fb2e09a5c381d6"
     ],
     credential_set_ids: [],
   },
@@ -39,6 +42,7 @@ let mockPermissionsResponse = {
       "0b07af48aa8991",
       "5fbd0cef5d9306",
       "c4c270d211fea2",
+      "8dfe7a96b0b5e4"
     ],
     credential_set_ids: [],
   },
@@ -47,62 +51,143 @@ let mockPermissionsResponse = {
 describe("Permissions", () => {
   let permissions;
   let sessionMock;
-  let consoleErrorSpy;
   let model;
   let ability;
   let appName;
-  const userId = 2;
+  let result;
 
   sessionMock = {
     apiCall: sinon.stub().resolves(mockPermissionsResponse),
   };
 
   let mockUser = {
-    id: "1"
-  }
-  
-  describe("load", () => {
+    id: "1",
+  };
+
+  describe("new Permission", () => {
     it("should throw an error if user ID or Session is not provided", async () => {
-      expect(() => new Permissions(sessionMock)).to.throw("User and Session is required.");
+      expect(() => new Permissions(sessionMock)).to.throw(
+        "User and Session is required."
+      );
       expect(() => new Permissions()).to.throw("User and Session is required.");
     });
+  });
 
-    it("should load a list of Permissions when userId is provided", async () => {
-      permissions = new Permissions(sessionMock, mockUser);
-      expect(permissions._permissions).to.not.exist;
-      await permissions.load(userId);
-      expect(permissions._permissions).to.exist;
+  describe("can-org", () => {
+    it("should return false when userRole is admin, memberRole is admin and lastAdmin is true ", async () => {
+      result = await permissions.can("removeMember", "Org", { memberRole: "admin", userRole: "admin", lastAdmin: true });
+      expect(result).to.be.false;
+
+    });
+    
+    it("should return true when userRole is admin, memberRole is admin and lastAdmin is true ", async () => {
+      result = await permissions.can("removeMember", "Org", { memberRole: "member", userRole: "admin", lastAdmin: true });
+      expect(result).to.be.true;
+    });
+
+    it("should return true when userRole is admin and lastAdmin is false", async () => {
+      result = await permissions.can("removeMember", "Org", { memberRole: "admin", userRole: "admin", lastAdmin: false });
+      expect(result).to.be.true;
+      result = await permissions.can("removeMember", "Org", { memberRole: "member", userRole: "admin", lastAdmin: false });
+      expect(result).to.be.true;
+    });
+
+    // userRole member automatically defaults to false before checking memberRole and lastAdmin
+    it("should return false when userRole is member", async () => {
+      result = await permissions.can("removeMember", "Org", { memberRole: "admin", userRole: "member", lastAdmin: false });
+      expect(result).to.be.false;
+      result = await permissions.can("removeMember", "Org", { memberRole: "member", userRole: "member", lastAdmin: false });
+      expect(result).to.be.false;
+      result = await permissions.can("removeMember", "Org", { memberRole: "admin", userRole: "member", lastAdmin: true });
+      expect(result).to.be.false;
+      result = await permissions.can("removeMember", "Org", { memberRole: "member", userRole: "member", lastAdmin: true });
+      expect(result).to.be.false;
+    });
+
+  })
+
+  beforeEach(() => {
+    permissions = new Permissions(sessionMock, mockUser);
+  });
+
+  describe("can-app", () => {
+
+    it("should return true when appropriate ability, model, and args are inputted", async () => {
+      appName = "8dfe7a96b0b5e4";
+      result = await permissions.can("update", "App", { appName: appName });
+      expect(result).to.be.true;
+      appName = "fb2e09a5c381d6"
+      result = await permissions.can("transfer", "App", { appName: appName });
+      expect(result).to.be.true;
+      appName = "5b83e11ab9ff8e"
+      result = await permissions.can("destroy", "App", { appName: appName });
+      expect(result).to.be.true;
+      appName = "a2dcf60ef9a7c3"
+      result = await permissions.can("grant", "App", { appName: appName });
+      expect(result).to.be.true;
+    });
+
+    it("should return false when app doesn't exist in users permissions", async () => {
+      appName = "i3bd0aefud13s6"; // random app name
+      result = await permissions.can("update", "App", { appName: appName });
+      expect(result).to.be.false;
     });
   });
 
-  describe("can", () => {
-    beforeEach(() => {
-      permissions = new Permissions(sessionMock, mockUser);
-      consoleErrorSpy = sinon.spy(console, "error");
-    });
-  
-    afterEach(() => {
-      consoleErrorSpy.restore();
-    });
-
-    it("should throw an error if model is not available", async () => {
-      model = "unknown";
-      appName = "i3bd0aefud13s6";
-      await permissions.can("update", model, { appName: appName });
-
-      expect(consoleErrorSpy.calledWith(`Model: ${model} not found`)).to.be
-        .true;
+  describe("validateModelAndAbility", () => {
+    it("should throw error when model is not found", async () => {
+      appName = "af6abd07ecdcdd";
+      try {
+        permissions.validate(mockPermissionsResponse, "update", "unknown", { appName: appName });
+        expectt.fail("Validation model fail did not pass");
+      } catch (error) {
+        expect(error.message).to.equal("Model: unknown not found");
+      }
     });
 
-    it("should throw an error if ability is not available for App", async () => {
-      ability = "unknown";
-      appName = "i3bd0aefud13s6";
-      await permissions.can("unknown", "App", { appName: appName });
-      expect(
-        consoleErrorSpy.calledWith(
-          `Ability: ${ability} not found in App permissions`
-        )
-      ).to.be.true;
+    it("should throw error when app ability is not found", async () => {
+      try {
+        appName = "af6abd07ecdcdd";
+        permissions.validateAppAbility(mockPermissionsResponse, "unknown", { appName: appName });
+        expectt.fail("Validation app ability fail did not pass");
+      } catch (error) {
+        expect(error.message).to.equal("Ability: unknown not found in App permissions");
+      }
+    });
+
+    it("should throw error when org ability is not found", async () => {
+      try {
+        permissions.validateOrgAbility("unknown", { memberRole: "admin", userRole: "member", lastAdmin: true });
+        expectt.fail("Validation org ability fail did not pass");
+      } catch (error) {
+        expect(error.message).to.equal("Ability: unknown not found in Org permissions");
+      }
     });
   });
+
+  describe("validateArgs", () => {
+    it("should throw an error if appropriate args are not set for validating org abilities", () => {
+      try {
+        permissions.validateOrgAbility("removeMember", {memberRole: undefined, userRole: undefined, lastAdmin: undefined});
+        expectt.fail("Validation for args fail did not pass");
+      } catch (error) {
+        expect(error.message).to.equal("memberRole, userRole, and lastAdmin are required in args");
+      }
+    })
+    it("should throw an error if appropriate args are not set for validating app abilities", () => {
+      try {
+        permissions.validateAppAbility(mockPermissionsResponse, "update", {appName: undefined});
+        expectt.fail("Validation for args fail did not pass");
+      } catch (error) {
+        expect(error.message).to.equal("appName is required in args");
+      }
+    })
+  })
+
+  describe("reset", () => {
+    it("should set _permissions to null when reset() is called", () => {
+      permissions.reset()
+      expect(permissions._permissions).to.equal(null);
+    })
+  })
 });

--- a/test/lib/Permissions.js
+++ b/test/lib/Permissions.js
@@ -53,45 +53,56 @@ describe("Permissions", () => {
   let appName;
   const userId = 2;
 
-  beforeEach(() => {
-    sessionMock = {
-      apiCall: sinon.stub().resolves(mockPermissionsResponse),
-    };
-    permissions = new Permissions(sessionMock);
-    consoleErrorSpy = sinon.spy(console, "error");
-  });
+  sessionMock = {
+    apiCall: sinon.stub().resolves(mockPermissionsResponse),
+  };
 
-  afterEach(() => {
-    consoleErrorSpy.restore();
-  });
-
+  let mockUser = {
+    id: "1"
+  }
+  
   describe("load", () => {
-    it("should throw an error if user ID is not provided", async () => {
-        await permissions.load();
-        expect(consoleErrorSpy.calledWith("Error loading permissions:", "User ID is required.")).to.be.true;
+    it("should throw an error if user ID or Session is not provided", async () => {
+      expect(() => new Permissions(sessionMock)).to.throw("User and Session is required.");
+      expect(() => new Permissions()).to.throw("User and Session is required.");
     });
 
-    it("should load a list of Permissions when userId is provided", async ()=> {
-        await permissions.load(userId);
-        expect(permissions._permissions).to.exist;
-    })
+    it("should load a list of Permissions when userId is provided", async () => {
+      permissions = new Permissions(sessionMock, mockUser);
+      expect(permissions._permissions).to.not.exist;
+      await permissions.load(userId);
+      expect(permissions._permissions).to.exist;
+    });
   });
 
   describe("can", () => {
+    beforeEach(() => {
+      permissions = new Permissions(sessionMock, mockUser);
+      consoleErrorSpy = sinon.spy(console, "error");
+    });
+  
+    afterEach(() => {
+      consoleErrorSpy.restore();
+    });
+
     it("should throw an error if model is not available", async () => {
-        model = "unknown"
-        appName = "i3bd0aefud13s6"
-        await permissions.load(userId);
-        await permissions.can('update', model, {appName: appName});  
-        expect(consoleErrorSpy.calledWith(`Model: ${model} not found`)).to.be.true;
-    })
+      model = "unknown";
+      appName = "i3bd0aefud13s6";
+      await permissions.can("update", model, { appName: appName });
+
+      expect(consoleErrorSpy.calledWith(`Model: ${model} not found`)).to.be
+        .true;
+    });
 
     it("should throw an error if ability is not available for App", async () => {
-        ability = "unknown"
-        appName = "i3bd0aefud13s6"
-        await permissions.load(userId);
-        await permissions.can("unknown", "App", {appName: appName});  
-        expect(consoleErrorSpy.calledWith(`Ability: ${ability} not found in App permissions`)).to.be.true;
-    })
-  })
+      ability = "unknown";
+      appName = "i3bd0aefud13s6";
+      await permissions.can("unknown", "App", { appName: appName });
+      expect(
+        consoleErrorSpy.calledWith(
+          `Ability: ${ability} not found in App permissions`
+        )
+      ).to.be.true;
+    });
+  });
 });

--- a/test/lib/Permissions.js
+++ b/test/lib/Permissions.js
@@ -1,0 +1,97 @@
+import chai from "chai";
+import sinon from "sinon";
+
+const expect = chai.expect;
+
+import Permissions from "../../src/models/Permissions.js";
+
+let mockPermissionsResponse = {
+  destroy: {
+    app_names: [
+      "af6abd07ecdcdd",
+      "0b07af48aa8991",
+      "5fbd0cef5d9306",
+      "c4c270d211fea2",
+    ],
+    credential_set_ids: [],
+  },
+  grant: {
+    app_names: [
+      "af6abd07ecdcdd",
+      "0b07af48aa8991",
+      "5fbd0cef5d9306",
+      "c4c270d211fea2",
+    ],
+    credential_set_ids: [],
+  },
+  transfer: {
+    app_names: [
+      "af6abd07ecdcdd",
+      "0b07af48aa8991",
+      "5fbd0cef5d9306",
+      "c4c270d211fea2",
+    ],
+    credential_set_ids: [],
+  },
+  update: {
+    app_names: [
+      "af6abd07ecdcdd",
+      "0b07af48aa8991",
+      "5fbd0cef5d9306",
+      "c4c270d211fea2",
+    ],
+    credential_set_ids: [],
+  },
+};
+
+describe("Permissions", () => {
+  let permissions;
+  let sessionMock;
+  let consoleErrorSpy;
+  let model;
+  let ability;
+  let appName;
+  const userId = 2;
+
+  beforeEach(() => {
+    sessionMock = {
+      apiCall: sinon.stub().resolves(mockPermissionsResponse),
+    };
+    permissions = new Permissions(sessionMock);
+    consoleErrorSpy = sinon.spy(console, "error");
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.restore();
+  });
+
+  describe("load", () => {
+    it("should throw an error if user ID is not provided", async () => {
+        await permissions.load();
+        expect(consoleErrorSpy.calledWith("Error loading permissions:", "User ID is required.")).to.be.true;
+    });
+
+    it("should load a list of Permissions when userId is provided", async ()=> {
+        await permissions.load(userId);
+        expect(permissions._permissions).to.exist;
+    })
+  });
+
+  describe("can", () => {
+    it("should throw an error if model is not available", async () => {
+        model = "unknown"
+        appName = "i3bd0aefud13s6"
+        await permissions.load(userId);
+        await permissions.can('update', model, {appName: appName});  
+        expect(consoleErrorSpy.calledWith(`Model: ${model} not found`)).to.be.true;
+    })
+
+    it("should throw an error if ability is not available for App", async () => {
+        ability = "unknown"
+        appName = "i3bd0aefud13s6"
+        await permissions.load(userId);
+        await permissions.can("unknown", "App", {appName: appName});  
+        expect(consoleErrorSpy.calledWith(`Ability: ${ability} not found in App permissions`)).to.be.true;
+    })
+  })
+});


### PR DESCRIPTION
This PR introduces a permissions class that will validate user permissions in the frontend. This will enable the hiding and displaying of components dependent on permissions. Examples: AppTransferManager, Organization Dashboard, and App Edit links. The permission model requires app ability, model, and args to check if certain user action are allowed. Example: Permissions.can('update', 'App', {appName: appName)

To-do's:

- [ ] Implement Tests
- [x] Add JSDoc Comment