### PR TITLE
panelbase should not inherit state for app

### DIFF
--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -151,7 +151,7 @@
       },
 
       ...mapState([
-        'apps', 'user', 'Permissions', 'app'])
+        'apps', 'user', 'Permissions'])
 
     },
 


### PR DESCRIPTION
Before
App panels on dashboard load with the parent's identity and crash

After
App panels on dashboard load as expected