### PR TITLE
support for passing USD as format

### DIFF
--- a/src/lib/Format.js
+++ b/src/lib/Format.js
@@ -12,7 +12,35 @@ export default class Format {
     return isNaN(out) ? token : out
   }
 
+  static currencySymbolConversions(str) {
+    let conversions = {
+      "USD": "$",
+      "GBP": "£",
+      "CAD": "$",
+
+      // These need to be tested before uncommenting. EUR in particular needs commas and periods swapped
+      // "EUR": "€",
+      // "JPY": "¥",
+      // "AUD": "$",
+      // "CNY": "¥",
+      // "CHF": "Fr",
+      // "SEK": "kr",
+      // "NZD": "$",
+      // "KRW": "₩",
+      // "SGD": "$",
+      // "NOK": "kr",
+      // "MXN": "$",
+      // "INR": "₹",
+      // "RUB": "₽",
+      // "ZAR": "R",
+      // "TRY": "₺",
+      // "BRL": "R$"
+    }
+    return conversions[str] || str
+  }
+
   static money(token=null, places=2, symbol='$') {
+    symbol = this.currencySymbolConversions(symbol)
     token = this.sanitize(token)
     if (token == null) { return '' }
     if (isNaN(token)) { return token }

--- a/test/lib/Format.js
+++ b/test/lib/Format.js
@@ -70,10 +70,17 @@ describe('Format', () => {
       expect(Format.money(1000, 0)).to.eql('$1,000')
     })
 
-    it('handles GBP', () => {
+    it('handles GBP symbol', () => {
       expect(Format.money(12, 2, '£')).to.eql('£12.00')
     })
 
+    it('handles GBP abbreviation', () => {
+      expect(Format.money(12, 2, 'GBP')).to.eql('£12.00')
+    })
+
+    it('handles a 3 character currency abbreviation', () => {
+      expect(Format.money(12, 2, 'USD')).to.eql('$12.00')
+    })
 
   })
 


### PR DESCRIPTION
Allows passing USD as an option to Format.

`expect(Format.money(12, 2, 'USD')).to.eql('$12.00')`