### PR TITLE
Format report groups the way OG dashboards expect

### DIFF
--- a/src/components/panels/PanelBase.vue
+++ b/src/components/panels/PanelBase.vue
@@ -235,7 +235,15 @@
       },
 
       preProcessResponse(response, status) {
-        return {statusCode: status, body: response}
+        let count = {}
+        for (let item of response.count) {
+          count[item.group] = item.value
+        }
+        let out = {
+          title: response.title,
+          count
+        }
+        return {statusCode: status, body: out}
       },
 
       fetchDataTrivialApp() {


### PR DESCRIPTION
**Before**
Existing dashboards that use trivial-api/reports are broken after a change to the response format to support deeper grouping
![Screenshot 2024-08-05 at 3 15 19 PM](https://github.com/user-attachments/assets/5e594f6d-1e8a-4d15-a98b-c52a2416bded)


**After**
Existing dashboards  load as expected, so long as they provide a `register_id` option.

![Screenshot 2024-08-05 at 3 12 34 PM](https://github.com/user-attachments/assets/953fd6e6-f201-44f5-9987-c6f72615aba7)


Note: Values show are generated samples from the Trivial Developers org on staging.