### PR TITLE
handle activity_entries index not returning payload

### DIFF
--- a/src/components/activityLog/JsonViewer.vue
+++ b/src/components/activityLog/JsonViewer.vue
@@ -213,6 +213,7 @@
     data() {
       return {
         diagnostics: {},
+        payload: {},
         resendText: 'Re-Send'
       }
     },
@@ -224,7 +225,7 @@
       },
 
       payloadDisplay() {
-        return formatJSON(this.webhook.payload) || 'Empty payload'
+        return formatJSON(this.payload) || 'Empty payload'
       },
 
       diagnosticsFilters() {
@@ -269,7 +270,8 @@
       async fetchEntry() {
         try {
           let entry = await this.$store.state.Session.apiCall(`/activity_entries/${this.webhook.id}`)
-         this.diagnostics = entry.diagnostics
+          this.diagnostics = entry.diagnostics
+          this.payload = entry.payload
         } catch (e) {
           console.error('[WebhooksTable][fetchData] Error:', e)
           notifications.error(`Could not load webhook: ${e.message}`)

--- a/src/components/activityLog/WebhooksTable.vue
+++ b/src/components/activityLog/WebhooksTable.vue
@@ -301,12 +301,6 @@ import { mapState } from 'vuex'
       return utc.toLocaleTimeString('en-us', options);
     },
 
-    payloadPreview(payload) {
-      let out = formatJSON(payload).replace(/\s+/g, ' ').trim()
-      out = (out == '') ? 'None' : out
-      return (out.length > 25) ? `${out.substring(0,25)}...` : out
-    },
-
     toggleExpanded(id) {
       this.expanded = {}
       this.expanded[id] = true;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -471,9 +471,13 @@ const store = createStore({
     async requireDataSample({ state, commit }) {
       if (!state.dataSample) {
         try {
-          const data = await Session.apiCall(`/webhooks?app_id=${state.app.name}&limit=1`)
+          // The activity_entries index does not return the payload, so we need to fetch the first entry,
+          // and then fetch the full entry to get the payload
+          const data = await Session.apiCall(`/activity_entries?app_id=${state.app.name}&limit=1`)
           if (Array.isArray(data) && data.length > 0) {
-            commit('setDataSample', data[0])
+            const id = data[0].id
+            const entry = await Session.apiCall(`/activity_entries/${id}`)
+            commit('setDataSample', {payload: entry.payload})
           } else {
             commit('setDataSample', {payload: {}})
           }


### PR DESCRIPTION
**Before**
The builder data sample and activity log assumes it will get a `payload` column back from `activity_entries#index`.


**After**
The builder assumes the `payload` column has to be fetched using the ActivityEntry.id, similar to `diagnostics`.


Also:
- Updates an outdated `/webhooks` endpoint, which redirects to activity_entries on the API controller anyway
- Removes an unused `payloadPreview` method that is never called
