### PR TITLE
Bugfix/stale app state

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="/assets/primevue-themes/aura-dark-blue/theme.css" id="theme-link" />
-    <title>Trivial Dashboard</title>
   </head>
 
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -44,12 +44,36 @@ export default {
 
     currentHeaderTitle() {
       return this.$route.params.paneltype || this.$route.name;
+    },
+
+    pageTitle() {
+      const baseTitle = 'Trivial'
+
+      let panelTypeOverride = null
+      if (this.$route.name === 'PanelType') {
+        panelTypeOverride = this.$route.params.paneltype
+        // So gross, but this whole concept is on its way out
+        panelTypeOverride = panelTypeOverride.charAt(0).toUpperCase() + panelTypeOverride.slice(1) + 's';
+      }
+      const routeTitle = panelTypeOverride ? panelTypeOverride : this.$route.name || ''
+      const dynamicData = store.state.app?.descriptive_name || ''
+
+      return `${routeTitle} ${dynamicData ? `- ${dynamicData}` : ''} | ${baseTitle}`.trim()
     }
+
   },
   provide() {
     return { ...(this.lastVars ?? {}) };
   },
   watch: {
+
+    pageTitle: {
+      immediate: true,
+      handler(newVal) {
+        document.title = newVal
+      }
+    },
+
     async currentRouteName(newVal) {
       store.dispatch("setCurrentPath", {
         currentPath: newVal,

--- a/src/components/InstanceSettings.vue
+++ b/src/components/InstanceSettings.vue
@@ -377,7 +377,6 @@
         this.descriptive_name = this.app.descriptive_name
         this.panels = this.app.panels
         this.schedule = this.app.schedule
-        window.document.title = `Settings: ${this.app.descriptive_name}`
       },
 
       async loadManifest() {

--- a/src/components/activityLog/WebhooksTable.vue
+++ b/src/components/activityLog/WebhooksTable.vue
@@ -215,11 +215,6 @@ import { mapState } from 'vuex'
     setTimeout(this.fetchData, 500)
 
   },
-  watch: {
-    async app(newApp) {
-      window.document.title = `Activity: ${newApp.descriptive_name}`
-    }
-  },
   computed: {
     appId() {
       return this.$route.params.id;

--- a/src/components/aside/Naviagation.vue
+++ b/src/components/aside/Naviagation.vue
@@ -7,9 +7,9 @@
 			</div>
 		</RouterLink>
 
-		<template v-if="isAppId">
+		<template v-if="app.id">
 			<template v-for="(value, index) in menuItems">
-				<RouterLink v-for="(sublink, index) in value?.sublinks" :key="index" :to="`/apps/${appName}${sublink.path}`" class="aside__nav__link aside__nav__link--sublink">
+				<RouterLink v-for="(sublink, index) in value?.sublinks" :key="index" :to="`/apps/${app.name}${sublink.path}`" class="aside__nav__link aside__nav__link--sublink">
 					<div>
 						<Icon :icon="sublink.icon" />
 						<span>{{ sublink.title }}</span>
@@ -68,8 +68,8 @@
 
 	onMounted(() => {})
 
-	const isAppId = computed(() => store.state.app.name ? true : false)
-	const appName = computed(() => store.state.app.name)
+	const app = computed(() => store.state.app)
 	const orgId = computed(() => useLocalStorage('orgId').value)
 	const orgSettingsPath = computed(() => `/organization-settings/${orgId.value}`)
+
 </script>

--- a/src/components/builderv2/Builder.vue
+++ b/src/components/builderv2/Builder.vue
@@ -90,11 +90,6 @@ export default {
       },
       deep: true,
     },
-    async app(newApp) {
-      if (newApp) {
-        window.document.title = `Edit: ${newApp.descriptive_name}`;
-      }
-    },
   },
 
   computed: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,7 @@ import DashboardView from "@/views/DashboardView.vue";
 import OrganizationSettingsView from "@/views/OrganizationsSettingsView.vue";
 import ContractsView from "@/views/ContractsView.vue";
 import Session from "../models/Session.js";
+import { useStore } from 'vuex';
 
 const routes = [
   { path: "/",
@@ -156,6 +157,7 @@ const redirectToSignIn = (to, loggedIn) => {
 }
 
 router.beforeEach(async (to, from) => {
+  const store = useStore();
   let loggedIn = await Session.validate();
   if (redirectToSignIn(to, loggedIn)) {
     return {
@@ -167,6 +169,12 @@ router.beforeEach(async (to, from) => {
       path: "/"
     }
   }
+
+  // Unset app if the destination route does not start with '/apps/:id'
+  if (!to.path.match(/^\/apps\/\w+/)) {
+    store.commit('setApp', {});
+  }
+
 })
 
 export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -114,7 +114,7 @@ const routes = [
   {
     path: "/dashboard3",
     component: DashboardView,
-    name: "Analytics and Real-Time Data",
+    name: "Dashboard",
   },
   {
     path: "/organization-settings/:id",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -364,7 +364,7 @@ const store = createStore({
 
     async loadResources({ commit }, { dispatch, router }) {
       const routeName = router.currentRoute.value.name
-      if ( ['PanelType', 'Show App'].includes(routeName) ) {
+      if ( ['PanelType', 'Show App', 'Sales', 'Dashboard'].includes(routeName) ) {
         await dispatch('loadApps', {dispatch})
       }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,6 +23,7 @@ const store = createStore({
     app: {},
     isAuthenticated: false,
     showSuperBar: false,
+    app: {},
     apps: [],
     manifest: {
       id: null,
@@ -339,7 +340,6 @@ const store = createStore({
       try {
         await dispatch('organizations')
         await dispatch('loadProfile')
-        await dispatch('initApp', { appId })
         await dispatch('loadResources', { dispatch, router })
         await dispatch('checkURLState')
         await dispatch('dashboards')
@@ -392,13 +392,6 @@ const store = createStore({
             app.canUpdate = res;
           });
       });
-    },
-    
-    initApp({state, commit}, {appId}) {
-      if(state.app !== {}){
-        state.app = {}
-      }
-      commit('setAppId', appId)
     },
 
     async setCurrentPath({state, commit}, {currentPath, route}) {


### PR DESCRIPTION
**Before**
- page needed a fresh load to display the sub menu for app nav
- sub nav links would be stale, especially problematic while editing an app, and then link to a previously viewed app's settings
- page title was inconsistent and often stale
- contracts and dashboard would not have results loaded if navigating from an original load of the Sales page

**After**
- side nav responds to any changes on app
- app is unset when navigating away from an apps/:id path
- page title logic is centralized and consistent
- landing on the sales page and navigating to contracts works as expected.