### PR TITLE
links point to modern contracts list, skeleton loader on activity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -145,6 +145,9 @@ export default {
             if (displayName != "All") {
               displayName = `${displayName}s`;
             }
+            if (displayName == 'Contracts') {
+              linkPath = '/contracts'
+            }
           }
           return { display: displayName, link: linkPath };
         });

--- a/src/components/aside/Naviagation.vue
+++ b/src/components/aside/Naviagation.vue
@@ -41,7 +41,7 @@
 		{ path: "/sales", title: 'Sales', icon: 'fa6-solid:sack-dollar' },
 		//{ path: "/#", title: 'Inventory', icon: 'fa6-solid:shirt' },
 		{ 
-			path: "/contract",
+			path: "/contracts",
 			title: 'Contracts', 
 			icon: 'fa6-solid:file-pen',
 			sublinks: [

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -131,7 +131,7 @@ const routes = [
     redirect: "/dashboard3",
   },
   {
-    path: "/contracts3",
+    path: "/contracts",
     component: ContractsView,
     name: "Contracts",
   },

--- a/src/views/ContractsView.vue
+++ b/src/views/ContractsView.vue
@@ -58,13 +58,18 @@
         <template #filterapply="{ filterCallback }">
           <Button type="button" @click="filterCallback()" label="Apply" severity="success" class="clear-btn" />
         </template>
-
         <template #body="{ data, field, index }">
           <span v-if="field === 'descriptive_name'">
               {{ data[field] }}
           </span>
-          <span v-else-if="field === 'stats'">
-            <template v-if="(data.totalErrors > 0 || data.totalSuccess > 0) && data.stats && data.stats.length">
+          <span v-if="field === 'stats'">
+
+
+            <template v-if="activityLoading">
+              <Skeleton width="3rem" height="2.5rem" />
+            </template>
+
+            <template v-else-if="(data.totalErrors > 0 || data.totalSuccess > 0) && data.stats && data.stats.length">
               <div>
                 <Button type="button" severity="secondary" text @click="togglePopup(data.id, $event)">
                   <svg version="1.1" xmlns="http://www.w3.org/2000/svg" height="20" width="26" class="chart">
@@ -141,7 +146,7 @@
     }),
     globalFilterFields = ['descriptive_name'],
     activityPopup = ref([]),
-
+    activityLoading = ref(false),
     activityQueryStr = "",
     activityQueryStr500 = "[{'name':'status','operator':'=','value':'500'}]",
     activityQueryStr200 = "[{'name':'status','operator':'=','value':'200'}]",
@@ -218,6 +223,7 @@
   }
 
   const getAppActivity = async () => {
+    activityLoading.value = true
     try {
       contracts.value = contracts.value.map(contract => ({
         ...contract,
@@ -243,8 +249,10 @@
         }
       })
     } catch (error) {
+      activityLoading.value = false
       console.error('Error in getAppActivity:', error)
     }
+    activityLoading.value = false
     return contracts
   }
 


### PR DESCRIPTION
**Before**
- Modern contracts list is available at `/contracts3`
- Side menu and breadcrumb links to `/contract` (no 's'), which renders by PanelType to AppsOverview
- Stats appear as blank while they are loading

After
- Modern contracts list is available at /contracts
- Deprecated version still available `/contact` with no changes
- Side menu and breadcrumb link to `/contracts`
- Stats appear as skeleton while loading

Loading demo with 2.5 seconds artificial delay added:
https://github.com/user-attachments/assets/09e09e4b-a673-4fb4-a572-e8a9edd9c754

