### PR TITLE
Feature/reprocess events

### DIFF
--- a/src/components/builderv2/InstanceActivity.vue
+++ b/src/components/builderv2/InstanceActivity.vue
@@ -15,33 +15,7 @@
     computed: {
       ...mapState(['app']),
       ...mapGetters(['appLoaded'])
-    },
-    data() {
-      return {
-        reprocess_start_at: '2024-10-01',
-      }
-    },
-    methods: {
-      handleReRun() {
-        if (!this.reprocess_start_at) {
-          alert('Please provide a date')
-          return
-        }
-
-        // if (confirm(`Are you sure you want to re-run all activity after ${this.reprocess_start_at}?`)) {
-          this.$store.state.Session.apiCall(`/apps/${this.app.name}/reprocess_activity`, 'PUT', {
-            start_at: this.reprocess_start_at
-          })
-          .then(() => {
-            alert('Activity re-run successfully')
-          })
-          .catch((err) => {
-            console.error(err)
-          })
-        // }
-      }
     }
-
   }
 
 </script>
@@ -51,6 +25,7 @@
     <!-- <super-bar></super-bar> -->
     <Notices></Notices>
     <!--<nav-tree :selected-title="'activity'"></nav-tree>-->
+
     <div class="instance-activity-items">
       <div class='app-name-container'>
         <h1 v-if = "appLoaded"><RouterLink :to="`/apps/${this.app.name}/builder2`">{{this.app.descriptive_name}}</RouterLink></h1>
@@ -59,34 +34,7 @@
       <FilterEditor></FilterEditor>
       <WebhooksTable></WebhooksTable>
     </div>
-
   </div>
-
-  <!-- Danger zone– re-run all activity after the date provided -->
-  <div class="danger-zone">
-    <h3>Refresh Sales</h3>
-    <p>Re-calculate all sales for this contract. This will: </p>
-    <ol>
-      <!-- TODO Since we could span across multiple contracts, this should be ~ app.tags.filter(tag => tag.name === 'customer').map(tag => tag.content) -->
-      <li>Delete all <strong>{{ app.descriptive_name }}</strong> sales after the cutoff that haven't been invoiced yet.</li>
-      <li>Calculate sales using the <strong>current version</strong>(s) of the {{ app.descriptive_name }} contract.</li>
-    </ol>
-
-    <!-- Why version(s)?
-
-      This reprocesses the activity stream, which selects the contract in effect for when work was performed.
-      If the activity spans across when one version of the contract was in effect and another, we will choose the correct contract version.
-
-     -->
-
-    <p>
-      <input v-model="reprocess_start_at" type="date" name="date" id="date">
-      <button @click="handleReRun">Re-run</button>
-    </p>
-  </div>
-
-
-
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/builderv2/InstanceActivity.vue
+++ b/src/components/builderv2/InstanceActivity.vue
@@ -15,7 +15,33 @@
     computed: {
       ...mapState(['app']),
       ...mapGetters(['appLoaded'])
+    },
+    data() {
+      return {
+        reprocess_start_at: '2024-10-01',
+      }
+    },
+    methods: {
+      handleReRun() {
+        if (!this.reprocess_start_at) {
+          alert('Please provide a date')
+          return
+        }
+
+        // if (confirm(`Are you sure you want to re-run all activity after ${this.reprocess_start_at}?`)) {
+          this.$store.state.Session.apiCall(`/apps/${this.app.name}/reprocess_activity`, 'PUT', {
+            start_at: this.reprocess_start_at
+          })
+          .then(() => {
+            alert('Activity re-run successfully')
+          })
+          .catch((err) => {
+            console.error(err)
+          })
+        // }
+      }
     }
+
   }
 
 </script>
@@ -25,7 +51,6 @@
     <!-- <super-bar></super-bar> -->
     <Notices></Notices>
     <!--<nav-tree :selected-title="'activity'"></nav-tree>-->
-
     <div class="instance-activity-items">
       <div class='app-name-container'>
         <h1 v-if = "appLoaded"><RouterLink :to="`/apps/${this.app.name}/builder2`">{{this.app.descriptive_name}}</RouterLink></h1>
@@ -34,7 +59,34 @@
       <FilterEditor></FilterEditor>
       <WebhooksTable></WebhooksTable>
     </div>
+
   </div>
+
+  <!-- Danger zone– re-run all activity after the date provided -->
+  <div class="danger-zone">
+    <h3>Refresh Sales</h3>
+    <p>Re-calculate all sales for this contract. This will: </p>
+    <ol>
+      <!-- TODO Since we could span across multiple contracts, this should be ~ app.tags.filter(tag => tag.name === 'customer').map(tag => tag.content) -->
+      <li>Delete all <strong>{{ app.descriptive_name }}</strong> sales after the cutoff that haven't been invoiced yet.</li>
+      <li>Calculate sales using the <strong>current version</strong>(s) of the {{ app.descriptive_name }} contract.</li>
+    </ol>
+
+    <!-- Why version(s)?
+
+      This reprocesses the activity stream, which selects the contract in effect for when work was performed.
+      If the activity spans across when one version of the contract was in effect and another, we will choose the correct contract version.
+
+     -->
+
+    <p>
+      <input v-model="reprocess_start_at" type="date" name="date" id="date">
+      <button @click="handleReRun">Re-run</button>
+    </p>
+  </div>
+
+
+
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/builderv2/InstanceRerun.vue
+++ b/src/components/builderv2/InstanceRerun.vue
@@ -61,7 +61,7 @@
       <button @click="handleReRun">Re-run</button>
     </p>
 
-    <pre>{{ streamedResponse.join('\n') }}</pre>
+    <pre><span v-for="line of streamedResponse">Rerun {{ line.run_id }}, {{ line.message }}<br /></span> </pre>
 
   </div>
 

--- a/src/components/builderv2/InstanceRerun.vue
+++ b/src/components/builderv2/InstanceRerun.vue
@@ -1,0 +1,92 @@
+<script>
+  import { mapState, mapGetters } from 'vuex'
+
+  export default {
+    computed: {
+      ...mapState(['app']),
+      ...mapGetters(['appLoaded'])
+    },
+    data() {
+      return {
+        rerun_start_at: '',
+        streamedResponse: []
+      }
+    },
+    methods: {
+      handleReRun() {
+        if (!this.rerun_start_at) {
+          alert('Please provide a date')
+          return
+        }
+
+        if (confirm(`Are you sure you want to re-run all ${this.app.descriptive_name} activity after ${this.rerun_start_at}?`)) {
+          this.$store.state.Session.apiCall(`/activity_entries/rerun`, 'PUT', {
+            app_id: this.app.name,
+            start_at: this.rerun_start_at
+          }, 'json', true, this.streamedResponse)
+          .catch((err) => {
+            console.error(err)
+          })
+        }
+      }
+    }
+
+  }
+
+</script>
+
+<template>
+  <div class="InstanceRerun">
+    <h1 v-if = "appLoaded"><RouterLink :to="`/apps/${this.app.name}/builder2`">{{this.app.descriptive_name}}</RouterLink></h1>
+  </div>
+
+  <h2 class="danger-zone">Danger zone</h2>
+
+  <div>
+    <h3>Refresh Sales</h3>
+    <p>Re-calculate all sales for this contract. This will: </p>
+    <ol>
+      <!-- TODO Since we could span across multiple contracts, this should be ~ app.tags.filter(tag => tag.name === 'customer').map(tag => tag.content) -->
+      <li>Delete all <strong>{{ app.descriptive_name }}</strong> sales after the cutoff that haven't been invoiced yet.</li>
+      <li>Calculate sales using the <strong>current version</strong>(s) of the {{ app.descriptive_name }} contract.</li>
+    </ol>
+    <p>Why version(s)?</p>
+    <p>
+      This re-runs the activity stream, which selects the contract in effect for when work was performed.
+      If the activity now spans across when multiple versions of the contract are in effect, which contract version is used may change.
+    </p>
+
+    <p>
+      <input v-model="rerun_start_at" type="date" name="date" id="date">
+      <button @click="handleReRun">Re-run</button>
+    </p>
+
+    <pre>{{ streamedResponse.join('\n') }}</pre>
+
+  </div>
+
+
+
+</template>
+
+<style lang="scss" scoped>
+  .InstanceRerun {
+    display: flex;
+  }
+  .danger-zone {
+    color: red;
+    text-transform: uppercase;
+    text-decoration: underline;
+
+  }
+
+  pre {
+    white-space: pre-wrap;
+    background: black;
+    color: white;
+    padding: 1em;
+    min-height: 40em;
+  }
+
+
+</style>

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -80,8 +80,8 @@ export default class Session {
         let chunk = partialLine + decoder.decode(value)
         const lines = chunk.split('\n')
         partialLine = lines.pop()
-        const message = JSON.parse(lines[0]).message
-        streamedResponse.push(message)
+        const data = JSON.parse(lines[0])
+        streamedResponse.push(data)
       }
     }
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,6 +12,7 @@ import Settings from "../components/Settings.vue";
 import AccountLocked from "../components/AccountLocked.vue";
 import InstanceSettings from "../components/InstanceSettings.vue";
 import InstanceActivity from "../components/builderv2/InstanceActivity.vue";
+import InstanceRerun from "../components/builderv2/InstanceRerun.vue";
 import Builder from "../components/builderv2/Builder.vue";
 import OrganizationSettings from "../components/OrganizationSettings.vue"; //THIS IS DEPRICATED FILE
 import OrganizationInviteUser from "../components/OrganizationInviteUser.vue";
@@ -88,6 +89,10 @@ const routes = [
   { path: "/apps/:id/activity",
     component: InstanceActivity,
     name: "Activity"
+  },
+  { path: "/apps/:id/rerun",
+    component: InstanceRerun,
+    name: "Rerun"
   },
   { path: "/apps/:id/builder2",
     component: Builder,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -368,7 +368,7 @@ const store = createStore({
         await dispatch('loadApps', {dispatch})
       }
 
-      if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings'].includes(routeName) ) {
+      if ( ['Activity', 'Show App', 'Builder', 'Panels', 'Settings', 'Rerun'].includes(routeName) ) {
         await dispatch('loadApp', { dispatch, appId: router.currentRoute.value.params.id })
       }
     },


### PR DESCRIPTION
**Before**
No ability to rerun the activity stream after contract changes have been made.

**After**
Unlinked utility page to delete register items and rerun the activity stream
![Screenshot 2024-11-21 at 1 19 59 PM](https://github.com/user-attachments/assets/c4e33eda-e967-4378-a2d0-7cebe80f3f5f)

Relies on 
https://github.com/solid-adventure/trivial-api/pull/338