### PR TITLE
default filter allows 2nd date constraint

### DIFF
--- a/src/views/SalesView.vue
+++ b/src/views/SalesView.vue
@@ -370,7 +370,7 @@
 		if (field == 'originated_at') {
 				filters.value[field] = { constraints: [
 					{ value: moment().tz(timezone).startOf('month').utc().format('L'), matchMode: 'dateAfter' }
-				]
+				], operator: 'and'
 			}
 		} else {
 			filters.value[field] = { constraints: [{ value: null, matchMode: defaultMatchMode }] }


### PR DESCRIPTION
**Before**
A second date filter cannot be added, this was inadvertently lost when[ adding the default date filter.](https://github.com/solid-adventure/trivial-ui/pull/197/commits/26a90bbf34d891e169add696732ee1dea1fe5370)
![Screenshot 2024-12-12 at 11 10 44 AM](https://github.com/user-attachments/assets/e5047fd5-1ab8-45b7-9f88-794c4c3d4328)

**After**
The "+ Add Rule" button is back in its original location

![Screenshot 2024-12-12 at 11 10 33 AM](https://github.com/user-attachments/assets/f1d4aafb-02e7-489b-840d-fc1b0daba3d2)
