### PR TITLE
refactor start, transparently render results

### DIFF
--- a/src/assets/stylesheets/pages/sales.scss
+++ b/src/assets/stylesheets/pages/sales.scss
@@ -93,6 +93,11 @@
 	}
 }
 
+th.header-right div.p-column-header-content {
+ 	display: flex;
+	justify-content: flex-end;
+}
+
 div.p-column-filter-buttonbar {
 	& button.p-button[aria-label="Apply"] {
 		color: white;

--- a/src/components/dashboard/table.vue
+++ b/src/components/dashboard/table.vue
@@ -5,45 +5,61 @@
 	        <div class="flex justify-content-between align-items-center">
 	          <h2 class="font-semibold">{{ chart.name }}</h2>
 
-	          <div>
-	          	<span class="mr-2">Group By</span>
-							<MultiSelect
-							  v-model="groupBy"
-							  :options="reportGroupOptions"
-							  optionLabel="label"
-							  optionValue="value"
-							  placeholder="Select Groups"
-							  display="chip"
-							  :maxSelectedLabels="4"
-							  class="w-full md:w-20rem"
-							/>
+						<div>
+						  <FloatLabel class="w-full md:w-20rem">
+						    <MultiSelect
+						      id="group-by"
+						      v-model="groupBy"
+						      :options="reportGroupOptions"
+						      optionLabel="label"
+						      optionValue="value"
+						      display="chip"
+						      :maxSelectedLabels="4"
+						      class="w-full"
+						    />
+						    <label for="group-by">Select Groups</label>
+						  </FloatLabel>
 						</div>
 
-	          <div>
-		          <span class="mr-2">Timezone</span>
-		          <Dropdown v-model="timezone" :options="chart.default_timezones" class="w-14rem" placeholder="Select Timezone" />
-		        </div>
+						<div>
+						  <FloatLabel class="w-14rem">
+						    <Dropdown
+						      id="timezone"
+						      v-model="timezone"
+						      :options="chart.default_timezones"
+						      class="w-full"
+						    />
+						    <label for="timezone">Timezone</label>
+						  </FloatLabel>
+						</div>
 
-	          <div>
-		          <span class="mr-2">Dates</span>
-		          <Dropdown v-model="namedDateRange"
-		          	:options="namedDateRanges()"
-		          	optionLabel="label"
-		          	optionValue="value"
-		          	class="w-14rem"
-		          	placeholder="Select Date Range"
-		          />
-		        </div>
+						<div>
+						  <FloatLabel class="w-14rem">
+						    <Dropdown
+						      id="date-range"
+						      v-model="namedDateRange"
+						      :options="namedDateRanges()"
+						      optionLabel="label"
+						      optionValue="value"
+						      class="w-full"
+						    />
+						    <label for="date-range">Dates</label>
+						  </FloatLabel>
+						</div>
 
-	          <div>
-		          <span class="mr-2">Group By</span>
-		          <Dropdown v-model="groupByPeriod" :options="groupByPeriodOptions()" class="w-14rem" placeholder="Select Date Group" />
-		        </div>
+						<div>
+						  <FloatLabel class="w-14rem">
+						    <Dropdown
+						      id="group-by-period"
+						      v-model="groupByPeriod"
+						      :options="groupByPeriodOptions()"
+						      class="w-full"
+						    />
+						    <label for="group-by-period">Group By</label>
+						  </FloatLabel>
+						</div>
 
-		        <div>
-		        	<span class="mr-2">Invert Sign</span>
-		        	<Checkbox v-model="invertSign" :binary="true" />
-		        </div>
+
 
 	        </div>
 	      </template>
@@ -106,7 +122,7 @@
 
 	   	<div class="footer-signature">
 	      <p>{{ formattedStartAt }} - {{ formattedEndAt }}, {{ timezone }} </p>
-				<p> Prepared at {{ new Date().toLocaleString(undefined, { timeZoneName: 'short' }) }}</p>
+				<p> Prepared {{ new Date().toLocaleString(undefined, { timeZoneName: 'short' }) }}</p>
 	    </div>
 
 
@@ -121,6 +137,7 @@
 	import { namedDateRanges, getDateRangeFromNamed } from '@/composable/namedDateRanges'
 	import loadingImg from '@/assets/images/trivial-loading-optimized.webp'
 	import moment from 'moment-timezone'
+	import FloatLabel from 'primevue/floatlabel';
 	import MultiSelect from 'primevue/multiselect';
 	import { useToastNotifications } from '@/composable/toastNotification'
 

--- a/src/components/dashboard/table.vue
+++ b/src/components/dashboard/table.vue
@@ -1,45 +1,59 @@
 <template>
-
-  <DataTable :value="tableData" :scrollable="true" scroll-height="400px">
-      <template #header>
-        <div class="flex justify-content-between align-items-center">
-          <h2 class="font-semibold">{{ chart.name }}</h2>
-        </div>
-      </template>
-
-      <template #empty>
-        <div class="flex justify-content-between align-items-center">
-          <h2 class="font-semibold">No data</h2>
-        </div>
-      </template>
-
-	    <Column v-for="(title, index) in groupBy"
-	            :key="title"
-	            :field="`group_${index}`"
-	            :header="title.replaceAll('_', ' ')"
-	            sortable :rowspan="groupBy.length"
-	            class="capitalize"
-	            :frozen="index === 0" />
-	    <Column v-for="period in periods"
-	            :key="period"
-	            :field="period"
-	            :header="period"
-	            class="text-right"
-	            sortable>
-	      <template #body="{ data, field }">
-	        {{ useFormatCurrency(data[field], 2) }}
+	<Panel class="w-full shadow-2">
+	  <DataTable :value="tableData" :scrollable="true" scroll-height="400px">
+	      <template #header>
+	        <div class="flex justify-content-between align-items-center">
+	          <h2 class="font-semibold">{{ chart.name }}</h2>
+	        </div>
 	      </template>
-	    </Column>
-	    <Column field="grandTotal"
-	            header="Grand Total"
-	            class="text-right font-bold"
-	            sortable>
-	      <template #body="{ data }">
-	        {{ useFormatCurrency(data.grandTotal, 2) }}
-	      </template>
-	    </Column>
-    </DataTable>
 
+	      <template #empty>
+	        <div class="flex justify-content-between align-items-center">
+	          <h2 class="font-semibold">No data</h2>
+	        </div>
+	      </template>
+
+	      <template #loading>
+	        <Image :src="loadingImg" alt="Loader" width="160" />
+	        <h3>Loading ...</h3>
+	      </template>
+
+		    <Column v-for="(title, index) in groupBy"
+		            :key="title"
+		            :field="`group_${index}`"
+		            :header="title.replaceAll('_', ' ')"
+		            sortable :rowspan="groupBy.length"
+		            class="capitalize"
+		            :frozen="index === 0" />
+		    <Column v-for="period in periods"
+		            :key="period"
+		            :field="period"
+		            :header="period"
+		            class="text-right"
+		            sortable>
+		      <template #body="{ data, field }">
+		        {{ useFormatCurrency(data[field], 2) }}
+		      </template>
+		    </Column>
+		    <Column field="grandTotal"
+		            header="Grand Total"
+		            class="text-right font-bold"
+		            sortable>
+		      <template #body="{ data }">
+		        {{ useFormatCurrency(data.grandTotal, 2) }}
+		      </template>
+		    </Column>
+
+				<ColumnGroup type="footer">
+	        <Row>
+	            <Column footer="Totals:" :colspan="groupBy.length" footerStyle="text-align:right" />
+	            <Column v-for="period in periods" :footer="useFormatCurrency(getTotalForPeriod(period), 2)" class="text-right" />
+	            <Column :footer="useFormatCurrency(grandTotals, 2)" class="text-right font-bold" />
+	        </Row>
+		    </ColumnGroup>
+
+	    </DataTable>
+	  </Panel>
 </template>
 
 <script setup>
@@ -63,8 +77,7 @@
 			headerCols = ref([]),
 			store = useStore()
 
-	let	grandTotals = ref(),
-		rawData = ref({})
+	const	rawData = ref({})
 
 	const groupBy = computed(() => {
 		const obj = props.chart.report_groups || {}
@@ -76,32 +89,51 @@
 	  return [...new Set(rawData.value.count.map(item => item.period))]
 	})
 
+  const grandTotals = computed(() => {
+	  if (!rawData.value?.count) return 0
+	  return rawData.value.count.reduce((acc, item) => {
+	    acc += parseFloat(item.value) || 0
+	    return acc
+	 	}, 0)
+	})
+
+	const getTotalForPeriod = period => {
+	  if (!rawData.value?.count) return 0
+	  return rawData.value.count.reduce((acc, item) => {
+	    if (item.period === period) {
+	      acc += parseFloat(item.value) || 0
+	    }
+	    return acc
+	  }, 0)
+	}
+
+
 	// Transform data for the table
-const tableData = computed(() => {
-  if (!rawData.value?.count) return []
-  const groupMap = new Map()
+	const tableData = computed(() => {
+	  if (!rawData.value?.count) return []
+	  const groupMap = new Map()
 
-  rawData.value.count.forEach(item => {
-    const groupKey = item.group.join('_')
-    if (!groupMap.has(groupKey)) {
-      const row = {
-        ...item.group.reduce((acc, val, idx) => {
-          acc[`group_${idx}`] = val || ''
-          return acc
-        }, {}),
-        grandTotal: 0
-      }
-      groupMap.set(groupKey, row)
-    }
+	  rawData.value.count.forEach(item => {
+	    const groupKey = item.group.join('_')
+	    if (!groupMap.has(groupKey)) {
+	      const row = {
+	        ...item.group.reduce((acc, val, idx) => {
+	          acc[`group_${idx}`] = val || ''
+	          return acc
+	        }, {}),
+	        grandTotal: 0
+	      }
+	      groupMap.set(groupKey, row)
+	    }
 
-    const currentValue = parseFloat(item.value) || 0
-    const row = groupMap.get(groupKey)
-    row[item.period] = currentValue // Store raw number
-    row.grandTotal += currentValue  // Add to running total
-  })
+	    const currentValue = parseFloat(item.value) || 0
+	    const row = groupMap.get(groupKey)
+	    row[item.period] = currentValue // Store raw number
+	    row.grandTotal += currentValue  // Add to running total
+	  })
 
-  return Array.from(groupMap.values())
-})
+	  return Array.from(groupMap.values())
+	})
 
 	onMounted(() => {
 		getData()

--- a/src/components/dashboard/table.vue
+++ b/src/components/dashboard/table.vue
@@ -28,7 +28,7 @@
 		            :header="title.replaceAll('_', ' ')"
 		            sortable :rowspan="groupBy.length"
 		            class="capitalize"
-		            :frozen="index === 0" />
+		            frozen alignFrozen="left" />
         <!-- Period group columns -->
 		    <Column v-for="period in periods"
 		            :key="period"
@@ -45,6 +45,7 @@
 		            header="Grand Total"
 		            class="text-right font-bold"
 		            headerClass="header-right"
+								frozen alignFrozen="right"
 		            sortable>
 		      <template #body="{ data }">
 		        {{ useFormatCurrency(data.grandTotal, 2) }}
@@ -53,9 +54,12 @@
 
 				<ColumnGroup type="footer">
 	        <Row>
-	            <Column footer="Totals:" :colspan="groupBy.length" footerStyle="text-align:right" />
+	            <Column footer="Totals:" :colspan="groupBy.length" footerStyle="text-align:right" frozen alignFrozen="left" />
 	            <Column v-for="period in periods" :footer="useFormatCurrency(getTotalForPeriod(period), 2)" class="text-right" />
-	            <Column :footer="useFormatCurrency(grandTotals, 2)" class="text-right font-bold" />
+	            <Column
+	            	:footer="useFormatCurrency(grandTotals, 2)"
+	            	class="text-right font-bold"
+								frozen alignFrozen="right" />
 	        </Row>
 		    </ColumnGroup>
 

--- a/src/components/dashboard/table.vue
+++ b/src/components/dashboard/table.vue
@@ -26,7 +26,13 @@
 
 	          <div>
 		          <span class="mr-2">Dates</span>
-		          <Dropdown v-model="namedDateRange" :options="namedDateRanges()" class="w-14rem" placeholder="Select Date Range" />
+		          <Dropdown v-model="namedDateRange"
+		          	:options="namedDateRanges()"
+		          	optionLabel="label"
+		          	optionValue="value"
+		          	class="w-14rem"
+		          	placeholder="Select Date Range"
+		          />
 		        </div>
 
 	          <div>
@@ -43,7 +49,7 @@
 	      </template>
 
 	      <template #empty>
-	        <div class="flex justify-content-between align-items-center">
+	        <div class="flex justify-content-center align-items-center">
 	          <h2 class="font-semibold">No data</h2>
 	        </div>
 	      </template>
@@ -98,8 +104,11 @@
 
 	    </DataTable>
 
-		          <p>Start: {{ startAt }}</p>
-		          <p>End: {{ endAt }}</p>
+	   	<div class="footer-signature">
+	      <p>{{ formattedStartAt }} - {{ formattedEndAt }}, {{ timezone }} </p>
+				<p> Prepared at {{ new Date().toLocaleString(undefined, { timeZoneName: 'short' }) }}</p>
+	    </div>
+
 
 	  </Panel>
 </template>
@@ -211,17 +220,35 @@
 
 	}
 
+	const formatDateRange = (date, isEndDate = false) => {
+	  if (!date || !timezone.value) return null
+	  return moment.utc(date)
+	    .tz(timezone.value)
+	    [isEndDate ? 'endOf' : 'startOf']('day')
+	    .utc()
+	    .toISOString()
+	}
+
+	const formatDisplayDate = (date) => {
+	  if (!date) return null
+	  return moment(date).tz(timezone.value).format('MM/DD/YYYY h:mm A')
+
+	}
+
 	const startAt = computed(() => {
-		if (!namedDateRange.value || !timezone.value) return null
-		let out = getDateRangeFromNamed(namedDateRange.value)[0]
-		return moment(out).tz(timezone.value).startOf('day').utc()
+	  if (!namedDateRange.value) return null
+	  const [start] = getDateRangeFromNamed(namedDateRange.value)
+	  return formatDateRange(start)
 	})
 
 	const endAt = computed(() => {
-		if (!namedDateRange.value || !timezone.value) return null
-		let out = getDateRangeFromNamed(namedDateRange.value)[1]
-		return moment(out).tz(timezone.value).endOf('day').utc()
+	  if (!namedDateRange.value) return null
+	  const [, end] = getDateRangeFromNamed(namedDateRange.value)
+	  return formatDateRange(end, true)
 	})
+
+	const formattedStartAt = computed(() => formatDisplayDate(startAt.value))
+	const formattedEndAt = computed(() => formatDisplayDate(endAt.value))
 
 	const getDataOptions = computed(() => {
 		return {
@@ -255,5 +282,14 @@
 			})
 	}
 
-
 </script>
+
+<style scoped>
+	div.footer-signature {
+		margin-top: 2rem;
+		font-size: 0.8rem;
+		display: flex;
+		justify-content: space-between;
+	}
+
+</style>

--- a/src/components/dashboard/table.vue
+++ b/src/components/dashboard/table.vue
@@ -60,11 +60,11 @@
 	      </template>
 
 	      <!-- Dynamic group by columns -->
-		    <Column v-for="(title, index) in groupBy"
+		    <Column v-for="(title, index) in groupByColumns"
 		            :key="title"
 		            :field="`group_${index}`"
 		            :header="title.replaceAll('_', ' ')"
-		            sortable :rowspan="groupBy.length"
+		            sortable :rowspan="groupByColumns.length"
 		            class="capitalize"
 		            frozen alignFrozen="left" />
         <!-- Period group columns -->
@@ -93,7 +93,7 @@
 		    <!-- Totals footer row -->
 				<ColumnGroup type="footer">
 	        <Row>
-	            <Column footer="Totals:" :colspan="groupBy.length" footerStyle="text-align:right" frozen alignFrozen="left" />
+	            <Column footer="Totals:" :colspan="groupByColumns.length" footerStyle="text-align:right" frozen alignFrozen="left" />
 	            <Column v-for="period in periods" :footer="useFormatCurrency(getTotalForPeriod(period), 2)" class="text-right" />
 	            <Column
 	            	:footer="useFormatCurrency(grandTotals, 2)"
@@ -136,7 +136,6 @@
 	const namedDateRange = ref('')
 	const timezone = ref('')
 	const invertSign = ref(false)
-	const groupByColumns = ref([])
 	const groupBy = ref([])
 
 	const { showSuccessToast, showErrorToast, showInfoToast } = useToastNotifications()
@@ -166,6 +165,10 @@
 	 	}, 0)
 	})
 
+  const groupByColumns = computed(() => {
+  	return groupBy.value.length > 0 ? groupBy.value : [""]
+  })
+
 	const getTotalForPeriod = period => {
 	  if (!rawData.value?.count) return 0
 	  return rawData.value.count.reduce((acc, item) => {
@@ -183,6 +186,7 @@
 	  const groupMap = new Map()
 
 	  rawData.value.count.forEach(item => {
+	  	item.group = Array.isArray(item.group) ? item.group : [item.group]
 	    const groupKey = item.group.join('_')
 	    if (!groupMap.has(groupKey)) {
 	      const row = {

--- a/src/composable/groupByPeriodOptions.js
+++ b/src/composable/groupByPeriodOptions.js
@@ -1,0 +1,10 @@
+export const groupByPeriodOptions = () => {
+
+	return [
+		'year',
+		'quarter',
+		'month',
+		'week',
+		'day'
+	]
+}

--- a/src/composable/namedDateRanges.js
+++ b/src/composable/namedDateRanges.js
@@ -1,0 +1,72 @@
+const titleize = (str) => {
+  // Handle special cases
+  if (str === 'ytd') return 'YTD';
+
+  // Split by underscores and hyphens
+  return str
+    .split(/[_-]/)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+export const namedDateRanges = () => {
+  const values = [
+    'today',
+    'yesterday',
+    'last_week',
+    'last_month',
+    'last_year',
+    'ytd',
+    'last_365_days',
+  ];
+
+  return values.map(value => ({
+    value,
+    label: titleize(value)
+  }));
+};
+
+export const getDateRangeFromNamed = name => {
+  let s = null
+  let e = null
+  switch (name) {
+  case 'today':
+    return [new Date(), new Date()]
+  case 'yesterday':
+    s = new Date()
+    s.setDate(s.getDate() - 1)
+    return [s, s]
+  case 'last_week':
+    s = new Date()
+    s.setDate(s.getDate() - (s.getDay() + 6) % 7)  // Monday of this week
+    s.setDate(s.getDate() - 8) // previous Sunday
+    e = new Date(s)
+    e.setDate(s.getDate() + 6)
+    return [s, e]
+  case 'last_month':
+    s = new Date()
+    s = new Date(s.getFullYear(), s.getMonth() - 1, 1)
+    e = new Date()
+    e = new Date(e.getFullYear(), e.getMonth(), 0)
+    return [s,e]
+  case 'last_year':
+    s = new Date()
+    s = new Date(s.getFullYear() - 1, 0, 1)
+    e = new Date(new Date().getFullYear() - 1, 11, 31)
+    return [s,e]
+  case 'ytd':
+    s = new Date()
+    s = new Date(s.getFullYear(), 0)
+    e = new Date()
+    return [s,e]
+  case 'last_365_days':
+    s = new Date()
+    s.setDate(s.getDate() - 364)
+    e = new Date()
+    return [s,e]
+  // case 'Custom':
+  //   return this.customDateRange
+  default:
+    return [s, e]
+  }
+}

--- a/src/composable/namedDateRanges.js
+++ b/src/composable/namedDateRanges.js
@@ -15,7 +15,12 @@ export const namedDateRanges = () => {
     'yesterday',
     'last_week',
     'last_month',
+    // 'last_quarter',
     'last_year',
+    // 'this_week',
+    // 'this_month',
+    // 'this_quarter',
+    // 'this_year',
     'ytd',
     'last_365_days',
   ];

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,5 +1,13 @@
 <template>
 	<div class="flex flex-column row-gap-4 dashboard">
+
+
+		<!-- Feature stub -->
+		<div v-if="createInvoicesEnabled" class="action-row">
+			<Button value="Create Invoices" class="p-button-primary" @click.prevent="handleCreateInvoices">Create Invoices</Button>
+		</div>
+
+
 		<div v-if="allCharts.length === 0" class="flex justify-content-center align-items-center w-full h-screen">
 			<ProgressSpinner aria-label="Loading" />
 		</div>
@@ -13,6 +21,7 @@
 
 <script setup>
 	import { ref, onMounted, computed, watch, toRaw } from 'vue'
+	import { useRoute } from 'vue-router'
 	import { useStore } from 'vuex'
 	import moment from 'moment-timezone'
 	import table from '@/components/dashboard/table.vue'
@@ -36,9 +45,13 @@
 	let dashboard = null,
 		allCharts = ref([])
 
+	const route = useRoute()
 	const orgId = computed(() => store.getters.getOrgId)
 	const regId = computed(() => store.getters.getRegisterId)
 	const dashboards = computed(() => store.getters.getDashboards)
+	const createInvoicesEnabled = computed(() => {
+		return route.query.createInvoices === 'true'
+	})
 
 	watch(orgId, async (newVal, oldVal) => await dashboardInit(newVal))
 	watch(regId, async (newVal, oldVal) => await dashboardInit(orgId.value))
@@ -91,51 +104,16 @@
 		}
 	}
 
-	/************  API Calls Functions ***************/
-	/*
-		channel: null
-		customer_id: null
-		entity_id: null
-		entity_type: null
-		income_account: true
-		warehouse: false
-	*/
-	/*const createChart = async dashId => {
-		try {
-			let res = await store.state.Session.apiCall(`dashboards/${dashId}/charts`, 'POST', {
-				"register_id": regId,
-				"name": "Actuals",
-				"chart_type": "summary_group",
-				"color_scheme": "default",
-				"report_period": "year",
-				"report_groups": {
-				}
-			})
-			
-			console.log('RES CREATED - ', res)
-		} catch (err) {
-			console.log(err)
-		}
+	const handleCreateInvoices = () => {
+		console.log('TODO: Create Invoices')
+		showSuccessToast('Success', 'Invoices created successfully.')
 	}
 
-	const updateChart = async dashId => {
-		try {
-			let res = await store.state.Session.apiCall(`dashboards/${dashId}/charts/5`, 'PUT', {
-				"name": "Example 3",
-				"chart_type": "doughnut",
-				"color_scheme": "red",
-				"report_period": "month",
-				"report_groups": {
-					"income_account": true,
-					"warehouse": true
-				}
-			})
-			
-			console.log('RES UPDATED - ', res)
-		} catch (err) {
-			console.log(err)
-		}
-	}
-
-	*/
 </script>
+
+<style scoped>
+	div.action-row {
+		display: flex;
+		justify-content: flex-end;
+	}
+</style>


### PR DESCRIPTION
**Before**
- group by is being retrieved from localstorage instead of chart API
- chart data is not respecting timezone saved to API
- columns are hardcoded date abbreviations
- data is duplicated

**After**
Refactored to address above.
![Screenshot 2024-12-12 at 2 31 39 PM](https://github.com/user-attachments/assets/195d748a-ab4e-495c-b22e-72104bc51a95)

TODO
- [x] Overrides for chart defaults (TZ, groups, group by period, date ranges)
- [x] TZ is stubbed as first `chart.default_timezones`
- [x] Handle single group scenario
- [ ] Consider moving `getDataOptions` and `getData` methods to be reusable for all charts
- [ ] Refactor other chart types
- [ ] Handle scenario where no register is found for the org (currently loads indefinitely)


